### PR TITLE
Refresca las tarjetas KPI de pagos contabilizados

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -53,6 +53,23 @@ def _segment_card(title: str, primary: str, stats: list[tuple[str, str]]) -> str
     )
 
 
+def _render_kpi_stat_cards(items: list[tuple[str, str]]) -> None:
+    if not items:
+        return
+    cards = []
+    for label, value in items:
+        cards.append(
+            "<article class=\"app-kpi-card\">"
+            f"<span class=\"app-kpi-card__label\">{html.escape(label)}</span>"
+            f"<span class=\"app-kpi-card__value\">{html.escape(value)}</span>"
+            "</article>"
+        )
+    st.markdown(
+        '<div class="app-kpi-cards">' + "".join(cards) + '</div>',
+        unsafe_allow_html=True,
+    )
+
+
 def _render_percentile_cards(items: list[tuple[str, str, str | None]]):
     if not items:
         return
@@ -315,10 +332,11 @@ def _validity_note(series_days: pd.Series, label: str):
 # DSO ancho completo + contadores + P50/P75/P90
 if dso_loc.notna().any():
     dso_num = pd.to_numeric(dso_loc, errors="coerce")
-    c1, c2, c3 = st.columns(3)
-    c1.metric("Pagadas ≤ 30 días", f"{int((dso_num<=30).sum()):,}")
-    c2.metric(f"Pagadas 31–{max_dias_pag} días", f"{int(((dso_num>30)&(dso_num<=max_dias_pag)).sum()):,}")
-    c3.metric(f"Pagadas > {max_dias_pag} días", f"{int((dso_num>max_dias_pag).sum()):,}")
+    _render_kpi_stat_cards([
+        ("Pagadas ≤ 30 días", f"{int((dso_num<=30).sum()):,}"),
+        (f"Pagadas 31–{max_dias_pag} días", f"{int(((dso_num>30)&(dso_num<=max_dias_pag)).sum()):,}"),
+        (f"Pagadas > {max_dias_pag} días", f"{int((dso_num>max_dias_pag).sum()):,}"),
+    ])
 
     fig_dso, _ = _hist_with_two_means(dso_loc, bins_pag, BLUE, max_dias_pag,
                                       "Emisión → Pago (DSO)",

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -177,6 +177,62 @@ body {
   color: var(--app-success);
 }
 
+.app-kpi-cards {
+  display: grid;
+  gap: 1rem;
+  margin: 1rem 0 1.4rem;
+}
+
+@media (min-width: 768px) {
+  .app-kpi-cards {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.app-kpi-card {
+  position: relative;
+  overflow: hidden;
+  padding: 1.35rem 1.5rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(145deg, rgba(79, 156, 255, 0.16), rgba(19, 37, 66, 0.65));
+  border: 1px solid rgba(79, 156, 255, 0.24);
+  box-shadow: 0 20px 40px rgba(9, 24, 46, 0.3);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.app-kpi-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.18), transparent 55%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.app-kpi-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(79, 156, 255, 0.45);
+  box-shadow: 0 28px 46px rgba(12, 28, 52, 0.35);
+}
+
+.app-kpi-card__label {
+  position: relative;
+  display: block;
+  font-size: 0.82rem;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--app-text-muted);
+  margin-bottom: 0.65rem;
+}
+
+.app-kpi-card__value {
+  position: relative;
+  font-size: 2.15rem;
+  font-weight: 600;
+  color: var(--app-text);
+  line-height: 1.1;
+}
+
 .stDownloadButton button,
 .stButton button {
   background: linear-gradient(135deg, rgba(79, 156, 255, 0.9), rgba(69, 130, 230, 0.9));


### PR DESCRIPTION
## Summary
- reemplaza los contadores de pagos contabilizados por tarjetas HTML acordes al lenguaje visual del tablero
- agrega estilos modernos para las tarjetas KPI y la grilla asociada en el tema global

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4800217e8832cb9b2f67d0aad3bf7