### PR TITLE
feat: armoniza tarjetas de Pagadas con estilo principal

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -281,6 +281,42 @@ mean_dso_loc = float(np.nanmean(dso_loc)) if dso_loc.notna().any() else np.nan
 mean_tfc_loc = float(np.nanmean(tfc_loc)) if tfc_loc.notna().any() else np.nan
 mean_tpc_loc = float(np.nanmean(tpc_loc)) if tpc_loc.notna().any() else np.nan
 
+# Reutilizamos las clases CSS de las tarjetas superiores para mantener coherencia visual.
+def _format_promedio(valor: float) -> str:
+    return f"{one_decimal(valor)} dias" if pd.notna(valor) else "s/d"
+
+pagadas_cards: list[str] = []
+if pd.notna(mean_dso_loc):
+    stats_dso = [
+        ("Promedio global", _format_promedio(mean_dso_kpi)),
+        ("Documentos", f"{int(pd.to_numeric(dso_loc, errors=\"coerce\").notna().sum()):,}"),
+    ]
+    pagadas_cards.append(
+        _segment_card("DSO (emision-pago)", _format_promedio(mean_dso_loc), stats_dso)
+    )
+
+if pd.notna(mean_tfc_loc):
+    stats_tfc = [
+        ("Promedio global", _format_promedio(mean_tfc_kpi)),
+        ("Documentos", f"{int(pd.to_numeric(tfc_loc, errors=\"coerce\").notna().sum()):,}"),
+    ]
+    pagadas_cards.append(
+        _segment_card("TFC (emision-contab.)", _format_promedio(mean_tfc_loc), stats_tfc)
+    )
+
+if pd.notna(mean_tpc_loc):
+    stats_tpc = [
+        ("Promedio global", _format_promedio(mean_tpc_kpi)),
+        ("Documentos", f"{int(pd.to_numeric(tpc_loc, errors=\"coerce\").notna().sum()):,}"),
+    ]
+    pagadas_cards.append(
+        _segment_card("TPC (contab.-pago)", _format_promedio(mean_tpc_loc), stats_tpc)
+    )
+
+if pagadas_cards:
+    # Al usar _segment_card heredamos el estilo "app-card" definido en styles/theme.css.
+    st.markdown('<div class="app-card-grid">' + "".join(pagadas_cards) + '</div>', unsafe_allow_html=True)
+
 def _hist_with_two_means(series: pd.Series, nbins: int, color: str,
                          xmax: int, title: str, mean_global: float, mean_local: float):
     vals = pd.to_numeric(series, errors="coerce")


### PR DESCRIPTION
## Summary
- reutilize el componente de tarjetas KPI para mostrar los promedios locales de Pagadas
- agregue métricas auxiliares para reflejar promedios globales y conteo de documentos con el mismo estilo visual

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e486f4b590832caf6cdd5de14d0781