### PR TITLE
fix: consolida layout de Pagadas en dos filas consistentes

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -56,16 +56,10 @@ def _segment_card(title: str, primary: str, stats: list[tuple[str, str]]) -> str
 def _render_kpi_stat_cards(items: list[tuple[str, str]]) -> None:
     if not items:
         return
-    cards = []
-    for label, value in items:
-        cards.append(
-            "<article class=\"app-kpi-card\">"
-            f"<span class=\"app-kpi-card__label\">{html.escape(label)}</span>"
-            f"<span class=\"app-kpi-card__value\">{html.escape(value)}</span>"
-            "</article>"
-        )
+    # Reutilizamos _metric_card para heredar la clase "app-card" y asegurar el mismo acabado.
+    cards = [_metric_card(label, value) for label, value in items]
     st.markdown(
-        '<div class="app-kpi-cards">' + "".join(cards) + '</div>',
+        '<div class="app-card-grid">' + "".join(cards) + '</div>',
         unsafe_allow_html=True,
     )
 
@@ -182,12 +176,10 @@ fact_pag = pd.to_numeric(df_kpi.get("fac_monto_total", 0.0), errors="coerce").wh
 contab_pag = pd.to_numeric(df_kpi.get("monto_autorizado", 0.0), errors="coerce").where(mask_base, other=0.0).sum()
 gap1_pct = (contab_pag / fact_pag - 1.0) * 100 if fact_pag > 0 else 0.0
 
+# Eliminamos la grilla duplicada de KPI; los valores de DSO/TFC/TPC se mostrarán una sola vez en la sección de Pagadas.
 metric_cards = [
     _metric_card("Monto total facturado", money(kpi["total_facturado"])),
     _metric_card("Total pagado (autorizado)", money(kpi["total_pagado_aut"])),
-    _metric_card("DSO (emision-pago)", f"{one_decimal(mean_dso_kpi)} dias"),
-    _metric_card("TFC (emision-contab.)", f"{one_decimal(mean_tfc_kpi)} dias"),
-    _metric_card("TPC (contab.-pago)", f"{one_decimal(mean_tpc_kpi)} dias"),
     _metric_card("Gap-1 %", f"{one_decimal(gap1_pct)}%"),
 ]
 st.markdown('<div class="app-card-grid">' + "".join(metric_cards) + '</div>', unsafe_allow_html=True)
@@ -281,6 +273,47 @@ mean_dso_loc = float(np.nanmean(dso_loc)) if dso_loc.notna().any() else np.nan
 mean_tfc_loc = float(np.nanmean(tfc_loc)) if tfc_loc.notna().any() else np.nan
 mean_tpc_loc = float(np.nanmean(tpc_loc)) if tpc_loc.notna().any() else np.nan
 
+# Reutilizamos _metric_card para que las 6 tarjetas compartan el estilo azul definido en styles/theme.css.
+def _format_promedio(valor: float) -> str:
+    return f"{one_decimal(valor)} dias" if pd.notna(valor) else "s/d"
+
+
+summary_cards: list[str] = []
+summary_cards.extend([
+    _metric_card(
+        "DSO (emision-pago)",
+        _format_promedio(mean_dso_loc),
+        caption=f"Promedio global: {_format_promedio(mean_dso_kpi)}",
+    ),
+    _metric_card(
+        "TFC (emision-contab.)",
+        _format_promedio(mean_tfc_loc),
+        caption=f"Promedio global: {_format_promedio(mean_tfc_kpi)}",
+    ),
+    _metric_card(
+        "TPC (contab.-pago)",
+        _format_promedio(mean_tpc_loc),
+        caption=f"Promedio global: {_format_promedio(mean_tpc_kpi)}",
+    ),
+])
+
+dso_num = pd.to_numeric(dso_loc, errors="coerce")
+dso_valid = dso_num[dso_num.notna()]
+count_le_30 = int((dso_valid <= 30).sum()) if not dso_valid.empty else 0
+count_mid = int(((dso_valid > 30) & (dso_valid <= max_dias_pag)).sum()) if not dso_valid.empty else 0
+count_gt = int((dso_valid > max_dias_pag).sum()) if not dso_valid.empty else 0
+
+summary_cards.extend([
+    _metric_card("Pagadas ≤ 30 días", f"{count_le_30:,}"),
+    _metric_card(f"Pagadas 31–{max_dias_pag} días", f"{count_mid:,}"),
+    _metric_card(f"Pagadas > {max_dias_pag} días", f"{count_gt:,}"),
+])
+
+st.markdown(
+    '<div class="app-card-grid">' + "".join(summary_cards) + '</div>',
+    unsafe_allow_html=True,
+)
+
 def _hist_with_two_means(series: pd.Series, nbins: int, color: str,
                          xmax: int, title: str, mean_global: float, mean_local: float):
     vals = pd.to_numeric(series, errors="coerce")
@@ -330,13 +363,7 @@ def _validity_note(series_days: pd.Series, label: str):
     )
 
 # DSO ancho completo + contadores + P50/P75/P90
-if dso_loc.notna().any():
-    dso_num = pd.to_numeric(dso_loc, errors="coerce")
-    _render_kpi_stat_cards([
-        ("Pagadas ≤ 30 días", f"{int((dso_num<=30).sum()):,}"),
-        (f"Pagadas 31–{max_dias_pag} días", f"{int(((dso_num>30)&(dso_num<=max_dias_pag)).sum()):,}"),
-        (f"Pagadas > {max_dias_pag} días", f"{int((dso_num>max_dias_pag).sum()):,}"),
-    ])
+if not dso_valid.empty:
 
     fig_dso, _ = _hist_with_two_means(dso_loc, bins_pag, BLUE, max_dias_pag,
                                       "Emisión → Pago (DSO)",


### PR DESCRIPTION
## Summary
- eliminé la segunda grilla de DSO/TFC/TPC para que solo se muestren en la sección local de Pagadas
- generé una única grilla de seis tarjetas (3 KPI + 3 rangos de Pagadas) reutilizando `app-card`
- añadí leyendas de promedio global en las tarjetas KPI locales y mantuve el conteo por rangos con el mismo estilo azul

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e486f4b590832caf6cdd5de14d0781