### PR TITLE
Style Pagadas KPI range cards

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -53,6 +53,25 @@ def _segment_card(title: str, primary: str, stats: list[tuple[str, str]]) -> str
     )
 
 
+def _range_card(title: str, value: str) -> str:
+    return (
+        '<div class="app-range-card">'
+        f'<div class="app-range-card__title">{html.escape(title)}</div>'
+        f'<div class="app-range-card__value">{html.escape(value)}</div>'
+        '</div>'
+    )
+
+
+def _render_range_cards(items: list[tuple[str, str]]):
+    if not items:
+        return
+    cards_html = "".join(_range_card(title, value) for title, value in items)
+    st.markdown(
+        '<div class="app-range-card-grid">' + cards_html + '</div>',
+        unsafe_allow_html=True,
+    )
+
+
 def _render_percentile_cards(items: list[tuple[str, str, str | None]]):
     if not items:
         return
@@ -315,10 +334,11 @@ def _validity_note(series_days: pd.Series, label: str):
 # DSO ancho completo + contadores + P50/P75/P90
 if dso_loc.notna().any():
     dso_num = pd.to_numeric(dso_loc, errors="coerce")
-    c1, c2, c3 = st.columns(3)
-    c1.metric("Pagadas ≤ 30 días", f"{int((dso_num<=30).sum()):,}")
-    c2.metric(f"Pagadas 31–{max_dias_pag} días", f"{int(((dso_num>30)&(dso_num<=max_dias_pag)).sum()):,}")
-    c3.metric(f"Pagadas > {max_dias_pag} días", f"{int((dso_num>max_dias_pag).sum()):,}")
+    _render_range_cards([
+        ("Pagadas ≤ 30 días", f"{int((dso_num <= 30).sum()):,}"),
+        (f"Pagadas 31–{max_dias_pag} días", f"{int(((dso_num > 30) & (dso_num <= max_dias_pag)).sum()):,}"),
+        (f"Pagadas > {max_dias_pag} días", f"{int((dso_num > max_dias_pag).sum()):,}"),
+    ])
 
     fig_dso, _ = _hist_with_two_means(dso_loc, bins_pag, BLUE, max_dias_pag,
                                       "Emisión → Pago (DSO)",

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -508,6 +508,59 @@ div[data-testid="stMetricValue"] {
   letter-spacing: 0.3px;
 }
 
+.app-range-card-grid {
+  display: grid;
+  gap: 1rem;
+  margin: 0.8rem 0 1.4rem;
+}
+
+@media (min-width: 768px) {
+  .app-range-card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.app-range-card {
+  position: relative;
+  padding: 1.15rem 1.3rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(150deg, rgba(34, 71, 140, 0.92), rgba(17, 36, 70, 0.88));
+  border: 1px solid rgba(79, 156, 255, 0.42);
+  box-shadow: 0 18px 40px rgba(9, 22, 46, 0.35);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.app-range-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.18), transparent 55%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.app-range-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 48px rgba(9, 22, 46, 0.42);
+}
+
+.app-range-card__title {
+  position: relative;
+  font-size: 0.82rem;
+  letter-spacing: 0.45px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.82);
+  margin-bottom: 0.55rem;
+}
+
+.app-range-card__value {
+  position: relative;
+  font-size: 1.95rem;
+  font-weight: 600;
+  color: #ffffff;
+  line-height: 1.1;
+}
+
 /* Boton del uploader con estilo propio y texto en espanol */
 .stFileUploader button[kind='secondary'] {
   background: linear-gradient(135deg, rgba(79, 156, 255, 0.95), rgba(51, 93, 173, 0.95));


### PR DESCRIPTION
## Summary
- replace the Pagadas KPI metrics with custom HTML cards so they can follow the dashboard styling
- add new range card styles to the shared theme to render a royal-blue background with white text

## Testing
- not run (streamlit app)


------
https://chatgpt.com/codex/tasks/task_e_68e5294bef4c832cbd1ecc1af7aba9e4