### PR TITLE
Estilizar tablas de presupuesto en informe asesor

### DIFF
--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -513,6 +513,10 @@ else:
             "dias_a_vencer":"Días a Vencer","importe_regla":"Monto",
             "cuenta_corriente":"Cuenta Corriente","banco":"Banco"
         })
+        for col in ("Fecha Factura", "Fecha Venc."):
+            if col in show:
+                fechas = pd.to_datetime(show[col], errors="coerce")
+                show[col] = fechas.dt.strftime("%d-%m-%Y").fillna("s/d")
         if "Proveedor Prioritario" in show:
             show["Proveedor Prioritario"] = show["Proveedor Prioritario"].map({True:"Sí", False:"No"})
         if "Cuenta Especial" in show:
@@ -540,7 +544,8 @@ else:
         return out
 
     st.markdown("**Candidatas a Pago (según criterio elegido)**")
-    st.dataframe(_prep_show(prior), use_container_width=True)
+    candidatas_display = _prep_show(prior)
+    style_table(_table_style(candidatas_display))
     st.download_button(
         "⬇️ Descargar Candidatas",
         data=excel_bytes_single(_prep_export(prior), "Candidatas"),
@@ -555,7 +560,8 @@ else:
         """,
         unsafe_allow_html=True,
     )
-    st.dataframe(_prep_show(seleccion), use_container_width=True)
+    seleccion_display = _prep_show(seleccion)
+    style_table(_table_style(seleccion_display))
     st.download_button(
         "⬇️ Descargar Selección de Hoy",
         data=excel_bytes_single(_prep_export(seleccion), "PagoHoy"),


### PR DESCRIPTION
## Summary
- Aplica el estilo profesional de tablas utilizado en los rankings a las vistas de presupuesto diario
- Formatea las columnas de fechas y mantiene la consistencia visual en los listados de candidatas y selección

## Testing
- python -m compileall pages/60_Informe_Asesor.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c845fb38832cbd9535cae0ab3d7d