### PR TITLE
Actualizar indicadores del forecast

### DIFF
--- a/pages/30_Forecast.py
+++ b/pages/30_Forecast.py
@@ -434,7 +434,7 @@ if clip_fc or clip_ci:
     _render_note("Se recortó en 0 el forecast o el límite inferior por la naturaleza de los pagos.")
 
 # ------------------------ resumen + explicación (GENERAL) ------------------------ #
-st.subheader("4. Resumen Numérico del Pronóstico")
+st.subheader("4. Resultados del Forecast — General")
 avg_hist = float(y.mean())
 avg_fc = float(np.mean(fc_plot["forecast"].values))
 var_pct = ((avg_fc - avg_hist) / avg_hist) * 100 if avg_hist > 0 else 0.0
@@ -470,7 +470,6 @@ cards_general = [
     },
     _mape_card(mape, thr_exc, thr_good, thr_ok),
 ]
-_render_metric_cards(cards_general)
 
 fc_display = fc_plot.copy()
 fc_display["fecha_g"] = pd.to_datetime(fc_display["fecha_g"])
@@ -492,6 +491,9 @@ export_general = display_general.rename(columns={"Valor Estimado": "Valor_Estima
 if "IC Bajo" in export_general.columns:
     export_general = export_general.rename(columns={"IC Bajo": "IC_Bajo", "IC Alto": "IC_Alto"})
 _excel_download(export_general, "Forecast_General", "forecast_general.xlsx")
+
+st.markdown("#### Indicadores del Forecast General")
+_render_metric_cards(cards_general)
 
 with st.expander("¿Cómo leer este bloque? (General)"):
     _metrics_explainer_block("General", thr_exc, thr_good, thr_ok)
@@ -595,7 +597,7 @@ else:
         )
         _excel_download(export_ce, "Forecast_CE", "forecast_cuentas_especiales.xlsx")
 
-    st.markdown("#### Resumen Numérico — Cuentas Especiales")
+    st.markdown("#### Indicadores del Forecast — Cuentas Especiales")
     avg_hist_ce = float(ts_ce.mean())
     avg_fc_ce = float(np.mean(yhat_out_ce))
     var_pct_ce = ((avg_fc_ce - avg_hist_ce) / avg_hist_ce) * 100 if avg_hist_ce > 0 else 0.0
@@ -729,7 +731,7 @@ else:
         )
         _excel_download(export_ne, "Forecast_NoCE", "forecast_cuentas_no_especiales.xlsx")
 
-    st.markdown("#### Resumen Numérico — Cuentas No Especiales")
+    st.markdown("#### Indicadores del Forecast — Cuentas No Especiales")
     avg_hist_ne = float(ts_ne.mean())
     avg_fc_ne = float(np.mean(yhat_out_ne))
     var_pct_ne = ((avg_fc_ne - avg_hist_ne) / avg_hist_ne) * 100 if avg_hist_ne > 0 else 0.0

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -600,9 +600,9 @@ div[data-testid="stMetricValue"] {
   position: relative;
   padding: 1.35rem 1.5rem;
   border-radius: var(--radius-md);
-  background: linear-gradient(145deg, rgba(13, 47, 102, 0.95), rgba(24, 80, 164, 0.92));
-  border: 1px solid rgba(79, 156, 255, 0.38);
-  box-shadow: 0 22px 48px rgba(12, 26, 52, 0.35);
+  background: #ffffff;
+  border: 1px solid rgba(13, 47, 102, 0.18);
+  box-shadow: 0 18px 42px rgba(8, 28, 72, 0.15);
   overflow: hidden;
   transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
 }
@@ -611,15 +611,15 @@ div[data-testid="stMetricValue"] {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.16), transparent 55%);
-  opacity: 0.65;
+  background: radial-gradient(circle at top right, rgba(79, 156, 255, 0.18), transparent 55%);
+  opacity: 0.5;
   pointer-events: none;
 }
 
 .forecast-card:hover {
   transform: translateY(-4px);
   border-color: rgba(79, 156, 255, 0.55);
-  box-shadow: 0 28px 56px rgba(12, 26, 52, 0.45);
+  box-shadow: 0 24px 52px rgba(8, 28, 72, 0.2);
 }
 
 .forecast-card__label {
@@ -627,7 +627,7 @@ div[data-testid="stMetricValue"] {
   font-size: 0.78rem;
   letter-spacing: 0.55px;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.82);
+  color: #1a3d7c;
 }
 
 .forecast-card__value {
@@ -635,14 +635,14 @@ div[data-testid="stMetricValue"] {
   margin-top: 0.45rem;
   font-size: 1.85rem;
   font-weight: 600;
-  color: #ffffff;
+  color: #0d2f66;
   letter-spacing: 0.35px;
 }
 
 .forecast-card__foot {
   margin-top: 0.75rem;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.88);
+  color: #3d4f73;
   line-height: 1.4;
 }
 
@@ -650,7 +650,7 @@ div[data-testid="stMetricValue"] {
   display: block;
   margin-top: 0.35rem;
   font-size: 0.78rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: #5a6c8f;
   letter-spacing: 0.35px;
 }
 
@@ -663,39 +663,39 @@ div[data-testid="stMetricValue"] {
   font-size: 0.78rem;
   font-weight: 600;
   letter-spacing: 0.35px;
-  border: 1px solid rgba(255, 255, 255, 0.32);
-  background: rgba(255, 255, 255, 0.16);
-  color: #ffffff;
+  border: 1px solid rgba(13, 47, 102, 0.12);
+  background: rgba(79, 156, 255, 0.12);
+  color: #0d2f66;
 }
 
 .forecast-chip--success {
-  background: rgba(66, 214, 164, 0.18);
-  border-color: rgba(66, 214, 164, 0.45);
-  color: #42d6a4;
+  background: rgba(66, 214, 164, 0.16);
+  border-color: rgba(66, 214, 164, 0.35);
+  color: #1f7f5e;
 }
 
 .forecast-chip--info {
-  background: rgba(79, 156, 255, 0.2);
-  border-color: rgba(79, 156, 255, 0.45);
-  color: #8cb8ff;
+  background: rgba(79, 156, 255, 0.16);
+  border-color: rgba(79, 156, 255, 0.35);
+  color: #204a92;
 }
 
 .forecast-chip--warning {
-  background: rgba(247, 185, 85, 0.22);
-  border-color: rgba(247, 185, 85, 0.45);
-  color: #f7b955;
+  background: rgba(247, 185, 85, 0.18);
+  border-color: rgba(247, 185, 85, 0.35);
+  color: #815414;
 }
 
 .forecast-chip--danger {
-  background: rgba(255, 99, 132, 0.22);
-  border-color: rgba(255, 99, 132, 0.45);
-  color: #ff6384;
+  background: rgba(255, 99, 132, 0.18);
+  border-color: rgba(255, 99, 132, 0.35);
+  color: #8c1f39;
 }
 
 .forecast-chip--neutral {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.28);
-  color: rgba(255, 255, 255, 0.88);
+  background: rgba(143, 160, 186, 0.18);
+  border-color: rgba(143, 160, 186, 0.32);
+  color: #4b5770;
 }
 
 .forecast-note {


### PR DESCRIPTION
## Summary
- mover los indicadores del forecast general debajo de la tabla proyectada y renombrar los encabezados
- alinear la nomenclatura de indicadores para cuentas especiales y no especiales
- actualizar el estilo de las tarjetas del forecast con fondo blanco y acentos azules consistentes

## Testing
- python -m compileall pages/30_Forecast.py

------
https://chatgpt.com/codex/tasks/task_e_68e5ca00a230832c80b8fe9ba49a83bf