### PR TITLE
Normalize KPI and table styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,18 +51,21 @@ def _card_html(
     actions: list[str] | None = None,
 ) -> str:
     status = "Listo" if ready else "Pendiente"
-    color = "#42d6a4" if ready else "#f7b955"
+    trend_class = "app-card__trend app-card__trend--success" if ready else "app-card__trend app-card__trend--warning"
     value = f"{rows:,}" if rows else "0"
     extras_html = "".join(extras) if extras else ""
     actions_html = "".join(actions) if actions else ""
+    hint_html = (
+        f'<p class="app-card__subtitle app-card__subtitle--muted">{hint}</p>' if hint else ""
+    )
     return (
         '<div class="app-card">'
         f'{actions_html}'
         f'<div class="app-card__title">{title}</div>'
         f'<div class="app-card__value">{value}</div>'
-        f'<div class="app-card__trend" style="color:{color};"><span>&bull; {status}</span></div>'
+        f'<div class="{trend_class}"><span>&bull; {status}</span></div>'
         f"{extras_html}"
-        f'<p style="margin-top:0.45rem;color:var(--app-text-muted);font-size:0.82rem;">{hint}</p>'
+        f"{hint_html}"
         '</div>'
     )
 

--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -21,10 +21,7 @@ PURP = "#8e44ad"   # línea promedio GLOBAL
 GRN  = "#2ecc71"
 
 def _metric_card(title: str, value: str, caption: str | None = None) -> str:
-    extra = (
-        f'<p style="margin-top:0.45rem;color:var(--app-text-muted);font-size:0.82rem;">{caption}</p>'
-        if caption else ""
-    )
+    extra = f'<p class="app-card__subtitle">{caption}</p>' if caption else ""
     return (
         '<div class="app-card">'
         f'<div class="app-card__title">{title}</div>'
@@ -37,7 +34,7 @@ def _metric_card(title: str, value: str, caption: str | None = None) -> str:
 def _stat_pill(label: str, value: str) -> str:
     return (
         '<div class="app-inline-stats__item">'
-        f'<span style="font-weight:600;color:var(--app-text);">{label}:</span> {value}'
+        f'<span class="app-inline-stats__label">{label}:</span> {value}'
         '</div>'
     )
 

--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -11,9 +11,9 @@ from lib_common import (
 from lib_report import excel_bytes_single, excel_bytes_multi
 
 # ================== Estilos globales de la tabla ==================
-HEADER_BG = "#003399"   # azul rey
-HEADER_FG = "#FFFFFF"   # blanco
-FONT_SIZE = "18px"      # <-- Ajusta aquí el tamaño de letra de TODA la tabla
+HEADER_BG = "var(--app-primary)"   # azul corporativo global
+HEADER_FG = "var(--app-table-header-fg)"   # texto encabezado global
+FONT_SIZE = "var(--app-table-font-size)"
 
 st.set_page_config(page_title="Rankings", layout="wide")
 header_ui(

--- a/pages/30_Forecast.py
+++ b/pages/30_Forecast.py
@@ -202,23 +202,23 @@ def _forecast_table_style(df_in: pd.DataFrame) -> pd.io.formats.style.Styler:
     sty = df_in.style.hide(axis="index")
     sty = sty.set_table_styles([
         {"selector": "thead tr", "props": [
-            ("background-color", "#0d2f66"),
-            ("color", "#FFFFFF"),
+            ("background-color", "var(--app-primary)"),
+            ("color", "var(--app-table-header-fg)"),
             ("text-transform", "uppercase"),
             ("letter-spacing", "0.6px"),
             ("font-weight", "600"),
-            ("font-size", "0.9rem"),
+            ("font-size", "var(--app-table-font-size)"),
         ]},
         {"selector": "th", "props": [
             ("background-color", "transparent"),
-            ("color", "#FFFFFF"),
+            ("color", "var(--app-table-header-fg)"),
             ("padding", "12px 16px"),
         ]},
         {"selector": "tbody td", "props": [
-            ("font-size", "0.95rem"),
+            ("font-size", "var(--app-table-font-size)"),
             ("padding", "12px 16px"),
             ("border-bottom", "1px solid #e0e6ff"),
-            ("color", "#132542"),
+            ("color", "var(--app-text-muted)"),
         ]},
         {"selector": "tbody tr:nth-child(even)", "props": [
             ("background-color", "#f5f7ff"),

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -25,11 +25,11 @@ header_ui(
 )
 
 # -------------------- Estilos locales para tablas --------------------
-TABLE_HEADER_BG = "#002b6f"
-TABLE_HEADER_FG = "#FFFFFF"
+TABLE_HEADER_BG = "var(--app-primary)"
+TABLE_HEADER_FG = "var(--app-table-header-fg)"
 TABLE_STRIPED_BG = "#f2f5ff"
 TABLE_HOVER_BG = "#e0e8ff"
-TABLE_FONT_SIZE = "16px"
+TABLE_FONT_SIZE = "var(--app-table-font-size)"
 TABLE_ROW_PADDING = "16px 22px"
 
 
@@ -150,7 +150,11 @@ def _card_html(
         classes.append("app-card--accent")
     title_html = html.escape(str(title))
     value_html = html.escape(str(value))
-    subtitle_html = f'<p style="margin:0;color:var(--app-text-muted);font-size:0.85rem;">{html.escape(str(subtitle))}</p>' if subtitle else ""
+    subtitle_html = (
+        f'<p class="app-card__subtitle">{html.escape(str(subtitle))}</p>'
+        if subtitle
+        else ""
+    )
     tag_html = ""
     if tag:
         tag_cls = "app-card__tag"
@@ -160,7 +164,7 @@ def _card_html(
     stats_html = ""
     if stats:
         pills = "".join(
-            f'<div class="app-inline-stats__item"><span style="font-weight:600;color:var(--app-text);">{html.escape(str(label))}:</span> {html.escape(str(val))}</div>'
+            f'<div class="app-inline-stats__item"><span class="app-inline-stats__label">{html.escape(str(label))}:</span> {html.escape(str(val))}</div>'
             for label, val in stats
         )
         stats_html = f'<div class="app-inline-stats">{pills}</div>'

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -639,6 +639,114 @@ div[data-testid="stMetricValue"] {
   letter-spacing: 0.35px;
 }
 
+/* ==================== Normalizacion KPI & Tablas ==================== */
+:root {
+  --kpi-title-size: clamp(0.78rem, 0.25vw + 0.74rem, 0.92rem);
+  --kpi-value-size: clamp(1.85rem, 0.8vw + 1.7rem, 2.25rem);
+  --kpi-subtitle-size: clamp(0.9rem, 0.35vw + 0.86rem, 1.05rem);
+  --app-table-font-size: clamp(0.92rem, 0.25vw + 0.9rem, 1.05rem);
+  --app-table-header-fg: #ffffff;
+}
+
+.app-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.app-card__title {
+  font-size: var(--kpi-title-size);
+  letter-spacing: 0.4px;
+  color: var(--app-text-muted);
+}
+
+.app-card__value {
+  font-size: var(--kpi-value-size);
+  font-weight: 600;
+  color: var(--app-text);
+  line-height: 1.12;
+}
+
+.app-card__subtitle {
+  margin: 0;
+  font-size: var(--kpi-subtitle-size);
+  color: var(--app-text-muted);
+  line-height: 1.35;
+}
+
+.app-card__subtitle--muted {
+  color: var(--app-text-muted);
+}
+
+.app-card__trend {
+  font-size: var(--kpi-subtitle-size);
+  color: var(--app-success);
+}
+
+.app-card__trend--success {
+  color: var(--app-success);
+}
+
+.app-card__trend--warning {
+  color: var(--app-accent);
+}
+
+.app-inline-stats__item {
+  font-size: var(--kpi-subtitle-size);
+}
+
+.app-inline-stats__label {
+  font-weight: 600;
+  color: var(--app-text);
+}
+
+/* Tablas base (st.table / st.dataframe / pandas styler) */
+div[data-testid="stTable"] table,
+.stDataFrame table,
+.styled-table-wrapper table,
+.ag-theme-streamlit {
+  font-size: var(--app-table-font-size);
+  color: var(--app-text);
+}
+
+div[data-testid="stTable"] thead tr,
+.stDataFrame table thead tr,
+.styled-table-wrapper table thead tr,
+.ag-theme-streamlit .ag-header {
+  background-color: var(--app-primary) !important;
+  color: var(--app-table-header-fg) !important;
+}
+
+div[data-testid="stTable"] thead th,
+.stDataFrame table thead th,
+.styled-table-wrapper table thead th,
+.ag-theme-streamlit .ag-header-cell,
+.ag-theme-streamlit .ag-header-cell-label {
+  background-color: transparent !important;
+  color: var(--app-table-header-fg) !important;
+  font-size: var(--app-table-font-size);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+div[data-testid="stTable"] tbody td,
+.stDataFrame table tbody td,
+.styled-table-wrapper table tbody td,
+.ag-theme-streamlit .ag-cell {
+  font-size: var(--app-table-font-size);
+  color: var(--app-text-muted);
+}
+
+.styled-table-wrapper thead th,
+.styled-table-wrapper thead tr {
+  border-radius: 0;
+}
+
+.ag-theme-streamlit .ag-header,
+.ag-theme-streamlit .ag-root-wrapper-body {
+  border-radius: var(--radius-md);
+}
+
 .forecast-card__foot {
   margin-top: 0.75rem;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- centralize KPI typography, subtitles, and trend colors across dashboard cards
- align table font sizing and header colors to the global theme using shared CSS variables
- refactor page helpers to rely on common classes instead of inline styling

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e5cfc749f8832c82547dbf6e248241