### PR TITLE
Ensure presupuesto respects horizon filter

### DIFF
--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -462,6 +462,10 @@ else:
 st.subheader("5) Presupuesto del Día (Selección Automática)")
 
 base = df_nopag_loc.copy()
+
+if "dias_a_vencer" in base.columns:
+    base = base[pd.to_numeric(base["dias_a_vencer"], errors="coerce") <= horizonte]
+
 if base.empty or "importe_deuda" not in base:
     st.info("No hay documentos pendientes para priorizar con los filtros locales.")
 else:


### PR DESCRIPTION
## Summary
- limit the dataset used for the daily budget selection to documents within the selected horizon
- ensure the filtered dataset is used when determining the default "Monto disponible hoy"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5e2d888e8832cbbfb872eab8c0a71