### PR TITLE
Handle Streamlit rerun deprecation in informe asesor

### DIFF
--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -724,7 +724,10 @@ else:
             formatted_text = _format_currency_plain(monto_presu)
             if presupuesto_text != formatted_text:
                 st.session_state[budget_input_key] = formatted_text
-                st.experimental_rerun()
+                try:
+                    st.rerun()
+                except AttributeError:
+                    st.experimental_rerun()
         with col_resume:
             st.markdown(
                 f"""


### PR DESCRIPTION
## Summary
- ensure the presupuesto input triggers a rerun using the modern `st.rerun()` API when available
- fall back to `st.experimental_rerun()` for older Streamlit versions

## Testing
- python -m compileall pages/60_Informe_Asesor.py

------
https://chatgpt.com/codex/tasks/task_e_68e5ed89d518832cb07bfee42fec5d36