### PR TITLE
Adjust table styling and clean up forecast markup

### DIFF
--- a/lib_common.py
+++ b/lib_common.py
@@ -141,6 +141,7 @@ def style_table(
                 width: 100% !important;
                 border-collapse: separate !important;
                 border-spacing: 0;
+                color: var(--app-table-body-fg);
             }
             </style>
             """,

--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -219,7 +219,8 @@ def _style_headers(df_disp: pd.DataFrame | pd.io.formats.style.Styler):
             ("font-size", FONT_SIZE),
             ("padding", "14px 18px"),
             ("text-align", "right"),
-            ("border-bottom", "1px solid #e0e6ff")
+            ("border-bottom", "1px solid #e0e6ff"),
+            ("color", "var(--app-table-body-fg)")
         ]},
         {"selector": "tbody tr:nth-child(even)", "props": [
             ("background-color", "#f5f7ff")

--- a/pages/30_Forecast.py
+++ b/pages/30_Forecast.py
@@ -218,7 +218,7 @@ def _forecast_table_style(df_in: pd.DataFrame) -> pd.io.formats.style.Styler:
             ("font-size", "var(--app-table-font-size)"),
             ("padding", "12px 16px"),
             ("border-bottom", "1px solid #e0e6ff"),
-            ("color", "var(--app-text-muted)"),
+            ("color", "var(--app-table-body-fg)"),
         ]},
         {"selector": "tbody tr:nth-child(even)", "props": [
             ("background-color", "#f5f7ff"),
@@ -250,11 +250,11 @@ header_ui(
     subtitle="Proyecciones sobre facturas pagadas (monto_autorizado en fecha_pagado)"
 )
 
-st.html('<div class="content-container">')
+st.markdown('<div class="content-container">', unsafe_allow_html=True)
 df0 = get_df_norm()
 if df0 is None:
     st.warning("Carga tus datos en 'Carga de Data' primero.")
-    st.html("</div>")
+    st.markdown("</div>", unsafe_allow_html=True)
     st.stop()
 
 fac_ini, fac_fin, pay_ini, pay_fin = general_date_filters_ui(df0)
@@ -273,7 +273,7 @@ df_filtrado = apply_advanced_filters(df_filtrado, sede, [], prov, cc, oc, [], pr
 df = df_filtrado[df_filtrado["estado_pago"] == "pagada"].copy()
 if df.empty or "fecha_pagado" not in df.columns or df["fecha_pagado"].isna().all():
     st.info("No hay datos de pagos con los filtros seleccionados.")
-    st.html("</div>")
+    st.markdown("</div>", unsafe_allow_html=True)
     st.stop()
 
 with st.expander("¿Qué datos se usan para el forecast?", expanded=True):
@@ -385,7 +385,7 @@ else:
         ci_low, ci_high = lb, ub
     except Exception as e:
         st.error(f"Error con Holt-Winters (Aditivo): {e}")
-        st.html("</div>")
+        st.markdown("</div>", unsafe_allow_html=True)
         st.stop()
 
 # ------------------------ visualización (GENERAL) ------------------------ #
@@ -771,4 +771,4 @@ else:
     with st.expander("¿Cómo leer este bloque? (Cuentas No Especiales)"):
         _metrics_explainer_block("Cuentas No Especiales", thr_exc, thr_good, thr_ok)
 
-st.html("</div>")
+st.markdown("</div>", unsafe_allow_html=True)

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -145,6 +145,7 @@ def _table_style(df_disp: pd.DataFrame | pd.io.formats.style.Styler):
             ("padding", TABLE_ROW_PADDING),
             ("text-align", "right"),
             ("border-bottom", "1px solid #d9e1ff"),
+            ("color", "var(--app-table-body-fg)"),
         ]},
         {"selector": "tbody tr:nth-child(even)", "props": [
             ("background-color", TABLE_STRIPED_BG)

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -22,6 +22,7 @@
   --hero-subtitle-color: rgba(255, 255, 255, 0.75);
   --hero-badge-bg: #1a0a29;
   --hero-badge-border: rgba(255, 255, 255, 0.35);
+  --app-table-body-fg: #1f2937;
 }
 
 /* Fondo principal del dashboard */
@@ -343,7 +344,7 @@ div[data-testid="stMetricValue"] {
 }
 
 .stDataFrame table {
-  color: var(--app-text);
+  color: var(--app-table-body-fg);
 }
 
 .stDataFrame th {
@@ -352,7 +353,7 @@ div[data-testid="stMetricValue"] {
 }
 
 .stDataFrame td {
-  color: var(--app-text-muted);
+  color: var(--app-table-body-fg);
 }
 
 .app-pill-group {
@@ -706,7 +707,7 @@ div[data-testid="stTable"] table,
 .styled-table-wrapper table,
 .ag-theme-streamlit {
   font-size: var(--app-table-font-size);
-  color: var(--app-text);
+  color: var(--app-table-body-fg);
 }
 
 div[data-testid="stTable"] thead tr,
@@ -734,7 +735,7 @@ div[data-testid="stTable"] tbody td,
 .styled-table-wrapper table tbody td,
 .ag-theme-streamlit .ag-cell {
   font-size: var(--app-table-font-size);
-  color: var(--app-text-muted);
+  color: var(--app-table-body-fg);
 }
 
 .styled-table-wrapper thead th,


### PR DESCRIPTION
## Summary
- add a dedicated table body color token and apply it across global CSS and per-page stylers for clearer data text
- ensure styled table wrapper markup inherits the new color setting
- replace raw `st.html` closing tags on the forecast page to avoid stray `</div>` artifacts

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5f52a1c20832cb14c73f0bcbe502b