### PR TITLE
Remove stray div closures and normalize table colors

### DIFF
--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -14,6 +14,9 @@ from lib_report import excel_bytes_single, excel_bytes_multi
 HEADER_BG = "var(--app-primary)"   # azul corporativo global
 HEADER_FG = "var(--app-table-header-fg)"   # texto encabezado global
 FONT_SIZE = "var(--app-table-font-size)"
+ROW_BORDER = "#d9e1ff"
+ROW_STRIPED_BG = "#f2f5ff"
+ROW_HOVER_BG = "#e0e8ff"
 
 st.set_page_config(page_title="Rankings", layout="wide")
 header_ui(
@@ -219,14 +222,14 @@ def _style_headers(df_disp: pd.DataFrame | pd.io.formats.style.Styler):
             ("font-size", FONT_SIZE),
             ("padding", "14px 18px"),
             ("text-align", "right"),
-            ("border-bottom", "1px solid #e0e6ff"),
+            ("border-bottom", f"1px solid {ROW_BORDER}"),
             ("color", "var(--app-table-body-fg)")
         ]},
         {"selector": "tbody tr:nth-child(even)", "props": [
-            ("background-color", "#f5f7ff")
+            ("background-color", ROW_STRIPED_BG)
         ]},
         {"selector": "tbody tr:hover", "props": [
-            ("background-color", "#e8edff")
+            ("background-color", ROW_HOVER_BG)
         ]},
         {"selector": "tbody td:first-child", "props": [
             ("text-align", "left"),

--- a/pages/30_Forecast.py
+++ b/pages/30_Forecast.py
@@ -23,6 +23,11 @@ from lib_common import (
 from lib_report import excel_bytes_single
 
 
+TABLE_BORDER_COLOR = "#d9e1ff"
+TABLE_STRIPED_BG = "#f2f5ff"
+TABLE_HOVER_BG = "#e0e8ff"
+
+
 # ------------------------ utilidades ------------------------ #
 def _agg_paid_series_like_general(df: pd.DataFrame, freq_alias: str) -> pd.DataFrame:
     """Serie de pagos (pagadas) agregada por fecha de pago y monto_autorizado>0."""
@@ -217,14 +222,14 @@ def _forecast_table_style(df_in: pd.DataFrame) -> pd.io.formats.style.Styler:
         {"selector": "tbody td", "props": [
             ("font-size", "var(--app-table-font-size)"),
             ("padding", "12px 16px"),
-            ("border-bottom", "1px solid #e0e6ff"),
+            ("border-bottom", f"1px solid {TABLE_BORDER_COLOR}"),
             ("color", "var(--app-table-body-fg)"),
         ]},
         {"selector": "tbody tr:nth-child(even)", "props": [
-            ("background-color", "#f5f7ff"),
+            ("background-color", TABLE_STRIPED_BG),
         ]},
         {"selector": "tbody tr:hover", "props": [
-            ("background-color", "#e8edff"),
+            ("background-color", TABLE_HOVER_BG),
         ]},
     ], overwrite=False)
     if df_in.shape[1] > 1:
@@ -250,11 +255,9 @@ header_ui(
     subtitle="Proyecciones sobre facturas pagadas (monto_autorizado en fecha_pagado)"
 )
 
-st.markdown('<div class="content-container">', unsafe_allow_html=True)
 df0 = get_df_norm()
 if df0 is None:
     st.warning("Carga tus datos en 'Carga de Data' primero.")
-    st.markdown("</div>", unsafe_allow_html=True)
     st.stop()
 
 fac_ini, fac_fin, pay_ini, pay_fin = general_date_filters_ui(df0)
@@ -273,7 +276,6 @@ df_filtrado = apply_advanced_filters(df_filtrado, sede, [], prov, cc, oc, [], pr
 df = df_filtrado[df_filtrado["estado_pago"] == "pagada"].copy()
 if df.empty or "fecha_pagado" not in df.columns or df["fecha_pagado"].isna().all():
     st.info("No hay datos de pagos con los filtros seleccionados.")
-    st.markdown("</div>", unsafe_allow_html=True)
     st.stop()
 
 with st.expander("¿Qué datos se usan para el forecast?", expanded=True):
@@ -385,7 +387,6 @@ else:
         ci_low, ci_high = lb, ub
     except Exception as e:
         st.error(f"Error con Holt-Winters (Aditivo): {e}")
-        st.markdown("</div>", unsafe_allow_html=True)
         st.stop()
 
 # ------------------------ visualización (GENERAL) ------------------------ #
@@ -771,4 +772,3 @@ else:
     with st.expander("¿Cómo leer este bloque? (Cuentas No Especiales)"):
         _metrics_explainer_block("Cuentas No Especiales", thr_exc, thr_good, thr_ok)
 
-st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- stop emitting orphaned closing `<div>` tags on the forecast page and rely on Streamlit controls for early exits
- standardize forecast and ranking table striping/hover colors with the shared palette variables

## Testing
- python -m compileall pages app.py lib_common.py lib_metrics.py lib_report.py core

------
https://chatgpt.com/codex/tasks/task_e_68e65150e5bc832cb4610949fc2cd33a