### PR TITLE
Eliminar literal <div></div> en tablas con estilo

### DIFF
--- a/lib_common.py
+++ b/lib_common.py
@@ -160,10 +160,18 @@ def style_table(
         if visible_rows is not None and visible_rows > 0:
             max_height = header_height + visible_rows * row_height
             extra_style = f"max-height:{max_height}px; overflow-y:auto;"
+        table_html = df.to_html()
+        # Algunas tablas generadas por pandas muestran un literal "<div></div>"
+        # como texto en celdas vacías. Eliminamos esos fragmentos o, en su
+        # defecto, los reemplazamos por un contenedor vacío sin contenido
+        # visible para que no aparezcan en la interfaz.
+        for unwanted in ("&lt;div&gt;&lt;/div&gt;", "<div></div>"):
+            if unwanted in table_html:
+                table_html = table_html.replace(unwanted, "")
         st.markdown(
             f"""
             <div class="styled-table-wrapper" style="{extra_style}">
-                {df.to_html()}
+                {table_html}
             </div>
             """,
             unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- limpia la salida HTML generada por pandas para eliminar el literal `<div></div>` que se mostraba en tablas
- mantiene el resto del estilo y configuración del contenedor de tabla intacto

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e654399acc832ca4e0d0a6137a9faf