### PR TITLE
feat: prevent orphan div closings and sanitize tables

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -11,7 +11,7 @@ from core.utils import LABELS, TOOLTIPS
 from lib_common import (
     get_df_norm, general_date_filters_ui, apply_general_filters,
     advanced_filters_ui, apply_advanced_filters, money, one_decimal, header_ui,
-    ESTADO_LABEL
+    ESTADO_LABEL, sanitize_df, safe_markdown
 )
 from lib_metrics import ensure_derived_fields, compute_kpis
 from lib_report import excel_bytes_multi
@@ -71,10 +71,7 @@ def _render_range_cards(items: list[tuple[str, str]]):
     if not items:
         return
     cards_html = "".join(_range_card(title, value) for title, value in items)
-    st.markdown(
-        '<div class="app-range-card-grid">' + cards_html + '</div>',
-        unsafe_allow_html=True,
-    )
+    safe_markdown('<div class="app-range-card-grid">' + cards_html + '</div>')
 
 
 def _render_percentile_cards(items: list[tuple[str, str, str | None]]):
@@ -94,7 +91,7 @@ def _render_percentile_cards(items: list[tuple[str, str, str | None]]):
             f'{helper_html}'
             '</div>'
         )
-    st.markdown('<div class="app-percentile-grid">' + "".join(cards) + '</div>', unsafe_allow_html=True)
+    safe_markdown('<div class="app-percentile-grid">' + "".join(cards) + '</div>')
    # línea promedio LOCAL
 
 st.set_page_config(page_title="Tablero KPI", layout="wide")
@@ -217,21 +214,20 @@ metric_cards = [
         tooltip=TOOLTIPS["brecha_porcentaje"],
     ),
 ]
-st.markdown('<div class="app-card-grid">' + "".join(metric_cards) + '</div>', unsafe_allow_html=True)
+safe_markdown('<div class="app-card-grid">' + "".join(metric_cards) + '</div>')
 
-st.markdown(
+safe_markdown(
     f"""
     <div class="app-note">
         <strong>{LABELS["brecha_porcentaje"]}</strong> = (Contabilizado pagado / Facturado pagado - 1) * 100.
         Facturado pagado = {money(fact_pag)} | Contabilizado pagado = {money(contab_pag)}.
     </div>
     """,
-    unsafe_allow_html=True,
 )
 
 # ====== KPIs por cuenta especial (Si/No) ======
 if "cuenta_especial" in df_kpi.columns:
-    st.markdown('<div class="app-separator"></div>', unsafe_allow_html=True)
+    safe_markdown('<div class="app-separator"></div>')
     st.markdown("### Metricas por cuenta especial")
 
     ce_mask_all = _coerce_bool_series(df_kpi["cuenta_especial"])
@@ -261,12 +257,12 @@ if "cuenta_especial" in df_kpi.columns:
         )
 
     if segment_cards:
-        st.markdown('<div class="app-card-grid">' + "".join(segment_cards) + '</div>', unsafe_allow_html=True)
+        safe_markdown('<div class="app-card-grid">' + "".join(segment_cards) + '</div>')
     else:
         st.info("Sin registros suficientes para evaluar segmentos de cuenta especial.")
 
 # ===================== Analisis interactivo de tiempos (filtros LOCALES) =====================
-st.markdown('<div class="app-separator"></div>', unsafe_allow_html=True)
+safe_markdown('<div class="app-separator"></div>')
 st.subheader("Analisis interactivo de tiempos")
 
 ctrl_row1 = st.columns(4)
@@ -431,7 +427,7 @@ with colB:
         st.info("Sin datos de Días desde Contabilización al Pago (DCP) en pagos contabilizados.")
 
 # ===================== NO PAGADAS — tiempos hasta hoy =====================
-st.markdown('<div class="app-separator"></div>', unsafe_allow_html=True)
+safe_markdown('<div class="app-separator"></div>')
 st.subheader("No Pagadas — tiempos *hasta hoy*")
 
 with st.expander("¿Cómo se calculan estos tiempos?"):
@@ -545,7 +541,7 @@ with c2:
         st.info("Sin registros en **Contabilizado sin Pago** con los filtros actuales.")
 
 # ===================== Composición del Portafolio =====================
-st.markdown('<div class="app-separator"></div>', unsafe_allow_html=True)
+safe_markdown('<div class="app-separator"></div>')
 st.subheader("Composición del Portafolio")
 
 modo = st.radio("Medir por…", ["Conteo de documentos","Monto Autorizado"], horizontal=True)
@@ -582,7 +578,7 @@ if "_ce_legible" in serie.columns:
     cols[3].plotly_chart(_pie(serie, "_ce_legible", "Cuenta Especial vs No"), use_container_width=True)
 
 # ===================== Exportación a Excel =====================
-st.markdown('<div class="app-separator"></div>', unsafe_allow_html=True)
+safe_markdown('<div class="app-separator"></div>')
 st.subheader("Exportar Dashboard a Excel (multi-hoja)")
 sheets = {}
 sheets["Pagadas"] = df_pag if not df_pag.empty else pd.DataFrame()

--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from lib_common import (
     get_df_norm, general_date_filters_ui, apply_general_filters,
-    advanced_filters_ui, apply_advanced_filters, header_ui, style_table, money
+    advanced_filters_ui, apply_advanced_filters, header_ui, style_table, money,
+    sanitize_df, safe_markdown
 )
 from lib_report import excel_bytes_single, excel_bytes_multi
 
@@ -241,13 +242,13 @@ def _style_headers(df_disp: pd.DataFrame | pd.io.formats.style.Styler):
     return sty
 
 # -------- Explicación de la regla --------
-st.markdown("---")
+safe_markdown("---")
 st.info("**Nota:** Un proveedor o centro se clasifica como *Prioritario* o *Cuenta Especial* = 'Sí' "
         "cuando el **50% o más** de sus documentos cumplen con esa condición en el período analizado. "
         "Las métricas y porcentajes reflejan el estado **actual** según los filtros globales y locales.")
 
 # -------- Top Proveedores --------
-st.markdown("---")
+safe_markdown("---")
 st.subheader("Top Proveedores")
 prov = agregar_ranking(
     dfp_f,
@@ -258,6 +259,7 @@ prov = agregar_ranking(
 # Formato de pantalla (no afecta Excel)
 prov_disp = _format_percent_cols_for_display(prov, ["% Cuenta Especial"])
 prov_disp = _format_money_cols_for_display(prov_disp, ["Monto Pagado"])
+prov_disp = sanitize_df(prov_disp)
 style_table(_style_headers(prov_disp))
 st.download_button(
     "⬇️ Descargar Ranking de Proveedores",
@@ -266,7 +268,7 @@ st.download_button(
 )
 
 # -------- Top Centros de Costo --------
-st.markdown("---")
+safe_markdown("---")
 st.subheader("Top Centros de Costo")
 if "nombre_centro_costo" in dfp_f.columns:
     cc = agregar_ranking(
@@ -277,6 +279,7 @@ if "nombre_centro_costo" in dfp_f.columns:
     )
     cc_disp = _format_percent_cols_for_display(cc, ["% Prioritario"])
     cc_disp = _format_money_cols_for_display(cc_disp, ["Monto Pagado"])
+    cc_disp = sanitize_df(cc_disp)
     style_table(_style_headers(cc_disp))
     st.download_button(
         "⬇️ Descargar Ranking de Centros de Costo",
@@ -337,7 +340,7 @@ def resumen_global(dfin: pd.DataFrame) -> dict[str, pd.DataFrame]:
     return out
 
 # -------- Exportar todo a Excel (multi-hoja) --------
-st.markdown("---")
+safe_markdown("---")
 st.subheader("Exportar Resultados de Rankings a Excel")
 
 sheets = {"RankingProveedores": prov}

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -12,7 +12,7 @@ from core.utils import LABELS, TOOLTIPS
 from lib_common import (
     get_df_norm, general_date_filters_ui, apply_general_filters,
     advanced_filters_ui, apply_advanced_filters, money, one_decimal, header_ui,
-    style_table,
+    style_table, sanitize_df, safe_markdown,
 )
 from lib_metrics import ensure_derived_fields, compute_kpis
 from lib_report import excel_bytes_single, generate_pdf_report
@@ -310,7 +310,7 @@ def _render_cards(cards: list[str], layout: str = "grid"):
         "grid-2": "app-grid-2",
         "grid-3": "app-grid-3",
     }.get(layout, "app-card-grid")
-    st.markdown(f'<div class="{wrapper}">{"".join(cards)}</div>', unsafe_allow_html=True)
+    safe_markdown(f'<div class="{wrapper}">{"".join(cards)}</div>')
 
 def _fmt_days(val: float) -> str:
     return "s/d" if pd.isna(val) else f"{one_decimal(val)} d"
@@ -388,7 +388,7 @@ else:
     _render_cards(cards)
 
     if "cuenta_especial" in df.columns:
-        st.markdown('<div class="app-separator"></div>', unsafe_allow_html=True)
+safe_markdown('<div class="app-separator"></div>')
         st.markdown("### Desglose por cuenta especial")
         segment_cards: list[str] = []
         for flag in (True, False):
@@ -466,6 +466,7 @@ if not df_pag.empty:
             "Días Promedio Pago": rankings_df["Días Promedio Pago"].map(one_decimal),
         }
     )
+    rankings_display = sanitize_df(rankings_display)
     style_table(_table_style(rankings_display))
     st.download_button(
         "⬇️ Descargar Ranking",
@@ -497,11 +498,10 @@ else:
     n2 = df_nopag[df_nopag["Nivel"].eq("Doc. Pendiente de Autorización")] if "Nivel" in df_nopag else df_nopag.iloc[0:0]
 
 def draw_debt_panel(title: str, dpanel: pd.DataFrame):
-    st.markdown(
+    safe_markdown(
         '<div class="app-title-block"><h3 style="color:#000;">'
         + html.escape(title)
-        + '</h3><p>Desglose por cuenta especial</p></div>',
-        unsafe_allow_html=True,
+        + '</h3><p>Desglose por cuenta especial</p></div>'
     )
     if "cuenta_especial" not in dpanel:
         st.info("Sin campo de Cuenta Especial para desglosar.")
@@ -660,6 +660,7 @@ if not df_nopag_loc.empty and "fecha_venc_30" in df_nopag_loc:
         small = flujo.head(3).rename(columns={"Fecha":"Día","Monto_a_Pagar":"Monto a Pagar","Cant_Facturas":"Cant. Facturas"})
         small_display = small.copy()
         small_display["Monto a Pagar"] = small_display["Monto a Pagar"].map(money)
+        small_display = sanitize_df(small_display)
         style_table(_table_style(small_display))
         fig = go.Figure()
         fig.add_bar(x=flujo["Fecha"], y=flujo["Monto_a_Pagar"], name="Monto Diario")
@@ -753,17 +754,16 @@ else:
     if budget_input_key not in st.session_state:
         st.session_state[budget_input_key] = _format_currency_plain(current_amount)
 
-    st.markdown(_BUDGET_PANEL_STYLE, unsafe_allow_html=True)
+safe_markdown(_BUDGET_PANEL_STYLE)
 
     with st.container():
-        st.markdown(
+        safe_markdown(
             """
             <div class="budget-panel">
                 <div class="budget-panel__title">Monto disponible hoy</div>
                 <div class="budget-panel__subtitle">Define tu presupuesto diario considerando cuentas críticas y prioridades.</div>
                 <div class="budget-panel__input-wrapper">
-            """,
-            unsafe_allow_html=True,
+            """
         )
         col_input, col_resume = st.columns([2.5, 1.5])
         with col_input:
@@ -788,15 +788,15 @@ else:
         with col_resume:
             amount_col, action_col = st.columns([1.7, 1.3])
             with amount_col:
-                st.markdown(
+                resume_html = (
                     f"""
                     <div class=\"budget-panel__resume\">
                         <span class=\"budget-panel__resume-label\">Equivale a</span>
                         <span class=\"budget-panel__resume-value\">{money(monto_presu)}</span>
                     </div>
-                    """,
-                    unsafe_allow_html=True,
+                    """
                 )
+                safe_markdown(resume_html)
             with action_col:
                 if next_info:
                     help_text = (
@@ -819,26 +819,22 @@ else:
                             st.rerun()
                         except AttributeError:
                             st.experimental_rerun()
-                    st.markdown(
-                        f"<p class='budget-panel__resume-note'>Próxima: {next_info['proveedor']} — Factura {next_info['documento']} ({money(next_info['monto'])})</p>",
-                        unsafe_allow_html=True,
+                    safe_markdown(
+                        f"<p class='budget-panel__resume-note'>Próxima: {next_info['proveedor']} — Factura {next_info['documento']} ({money(next_info['monto'])})</p>"
                     )
-                    st.markdown(
-                        f"<p class='budget-panel__resume-note budget-panel__resume-note--muted'>Ajuste necesario: {money(next_info['adicional'])}</p>",
-                        unsafe_allow_html=True,
+                    safe_markdown(
+                        f"<p class='budget-panel__resume-note budget-panel__resume-note--muted'>Ajuste necesario: {money(next_info['adicional'])}</p>"
                     )
                 else:
-                    st.markdown(
-                        "<p class='budget-panel__resume-note budget-panel__resume-note--muted'>No hay facturas adicionales por agregar.</p>",
-                        unsafe_allow_html=True,
+                    safe_markdown(
+                        "<p class='budget-panel__resume-note budget-panel__resume-note--muted'>No hay facturas adicionales por agregar.</p>"
                     )
-        st.markdown(
+        safe_markdown(
             """
                 </div>
                 <div class="budget-panel__helper">El valor se guarda automáticamente para esta sesión y se utilizará en el reporte PDF.</div>
             </div>
-            """,
-            unsafe_allow_html=True,
+            """
         )
 
 
@@ -877,6 +873,8 @@ tab_candidatas, tab_seleccion = st.tabs([
 
 candidatas_display = _prep_show(candidatas_prior)
 seleccion_display = _prep_show(seleccion)
+candidatas_display = sanitize_df(candidatas_display)
+seleccion_display = sanitize_df(seleccion_display)
 
 with tab_candidatas:
     st.markdown("**Candidatas a Pago (todas las facturas — ordenadas por riesgo de aprobación)**")
@@ -889,13 +887,12 @@ with tab_candidatas:
     )
 
 with tab_seleccion:
-    st.markdown(
+    safe_markdown(
         """
         <div class="app-note">
             <strong>Selección a pagar hoy</strong> — bloque crítico de pagos.
         </div>
         """,
-        unsafe_allow_html=True,
     )
     style_table(_table_style(seleccion_display), visible_rows=15)
     st.download_button(

--- a/scripts/check_orphan_divs.py
+++ b/scripts/check_orphan_divs.py
@@ -1,0 +1,17 @@
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+BAD = []
+pat = re.compile(r"st\.(markdown|write|text)\(\s*[fr]?[\"']\s*</div>\s*[\"']", re.I)
+for p in ROOT.rglob("*.py"):
+    if "venv" in p.parts:
+        continue
+    s = p.read_text(encoding="utf-8", errors="ignore")
+    if pat.search(s):
+        BAD.append(str(p))
+if BAD:
+    print("[ERROR] Cierres </div> huérfanos en:", *BAD, sep="\n - ")
+    sys.exit(1)
+print("[OK] Sin cierres </div> huérfanos detectados.")

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -711,6 +711,17 @@ div[data-testid="stMetricValue"] {
 }
 
 /* Tablas base (st.table / st.dataframe / pandas styler) */
+.block-container p:empty,
+.block-container div:empty {
+  display: none !important;
+}
+
+.stDataFrame td,
+[data-testid="stTable"] td {
+  color: #0f172a !important;
+  opacity: 1 !important;
+}
+
 div[data-testid="stTable"] table,
 .stDataFrame table,
 .styled-table-wrapper table,


### PR DESCRIPTION
## Summary
- add `sanitize_df` and `safe_markdown` helpers to block orphan closing tags and keep HTML balanced
- refactor Streamlit pages to sanitize DataFrames and use the safe helper for every HTML block
- harden table styling and add a checker script to catch orphan `</div>` usages

## Testing
- python scripts/check_orphan_divs.py

------
https://chatgpt.com/codex/tasks/task_e_68e6572b9a10832caf55f5b23e53141b