### PR TITLE
Add document status radio filter for dashboards

### DIFF
--- a/lib_metrics.py
+++ b/lib_metrics.py
@@ -177,9 +177,13 @@ def apply_common_filters(df: pd.DataFrame, filtros: Mapping[str, Any]) -> pd.Dat
     cc = filtros.get("cc", [])
     oc = filtros.get("oc", [])
     est = filtros.get("est", [])
+    estado_doc = filtros.get("estado_doc")
     prio = filtros.get("prio", [])
 
     base = apply_advanced_filters(base, sede, org, prov, cc, oc, est, prio)
+    if estado_doc not in (None, "", "Todos") and "estado_doc" in base.columns:
+        estado_norm = base["estado_doc"].astype(str)
+        base = base[estado_norm == str(estado_doc)]
     return base
 
 

--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -133,7 +133,33 @@ df0 = ensure_derived_fields(df0)
 
 # ===================== Filtros globales =====================
 fac_ini, fac_fin, pay_ini, pay_fin = general_date_filters_ui(df0)
-sede, org, prov, cc, oc, est, _prio_removed = advanced_filters_ui(df0)
+sede, org, prov, cc, oc, est, _prio_removed = advanced_filters_ui(
+    df0, show_controls=["sede", "org", "prov", "cc", "oc"]
+)
+
+estado_doc_options = [
+    "Todos",
+    "Autorizado sin Pago",
+    "Pagado",
+    "Facturado Sin Autorizar",
+]
+default_estado_doc = st.session_state.get("estado_doc_local", estado_doc_options[0])
+if default_estado_doc not in estado_doc_options:
+    default_estado_doc = estado_doc_options[0]
+estado_doc_choice = st.radio(
+    "Tipo de Doc./Estado (local)",
+    estado_doc_options,
+    horizontal=True,
+    index=estado_doc_options.index(default_estado_doc),
+    key="estado_doc_local",
+)
+estado_doc_map = {
+    "Todos": None,
+    "Autorizado sin Pago": "autorizada_sin_pago",
+    "Pagado": "pagada",
+    "Facturado Sin Autorizar": "sin_autorizacion",
+}
+estado_doc_value = estado_doc_map.get(estado_doc_choice)
 
 common_filters = {
     "fac_range": (fac_ini, fac_fin),
@@ -144,6 +170,7 @@ common_filters = {
     "cc": cc,
     "oc": oc,
     "est": est,
+    "estado_doc": estado_doc_value,
     "prio": [],
 }
 

--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -35,10 +35,35 @@ if df0 is None:
 # -------- Filtros globales (sin prioritario global) --------
 fac_ini, fac_fin, pay_ini, pay_fin = general_date_filters_ui(df0)
 sede, org, prov, cc, oc, est, _prio_removed = advanced_filters_ui(
-    df0, show_controls=['sede','org','prov','cc','oc','est']
+    df0, show_controls=['sede','org','prov','cc','oc']
 )
+estado_doc_options = [
+    "Todos",
+    "Autorizado sin Pago",
+    "Pagado",
+    "Facturado Sin Autorizar",
+]
+default_estado_doc = st.session_state.get("estado_doc_local", estado_doc_options[0])
+if default_estado_doc not in estado_doc_options:
+    default_estado_doc = estado_doc_options[0]
+estado_doc_choice = st.radio(
+    "Tipo de Doc./Estado (local)",
+    estado_doc_options,
+    horizontal=True,
+    index=estado_doc_options.index(default_estado_doc),
+    key="estado_doc_local",
+)
+estado_doc_map = {
+    "Todos": None,
+    "Autorizado sin Pago": "autorizada_sin_pago",
+    "Pagado": "pagada",
+    "Facturado Sin Autorizar": "sin_autorizacion",
+}
+estado_doc_value = estado_doc_map.get(estado_doc_choice)
 df = apply_general_filters(df0, fac_ini, fac_fin, pay_ini, pay_fin)
 df = apply_advanced_filters(df, sede, org, prov, cc, oc, est, prio=[])
+if estado_doc_value and "estado_doc" in df.columns:
+    df = df[df["estado_doc"].astype(str) == estado_doc_value]
 
 # Trabajamos con pagadas
 dfp = df[df["estado_pago"] == "pagada"].copy()


### PR DESCRIPTION
## Summary
- add a shared "Tipo de Doc./Estado" radio control below the advanced filters on KPI, Rankings, and Informe Asesor
- persist the selection in session state and pass it to the shared filtering pipeline so common KPI queries respect the chosen document status
- keep Informe Asesor downstream debt and budget sections using data without the document-status filter to avoid impacting local prioritisation flows

## Testing
- python -m compileall pages lib_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68e673dd4e38832c80aea9bb2d3d977d