### PR TITLE
Ajusta KPIs de facturación y elimina brecha

### DIFF
--- a/core/utils/ui_labels.py
+++ b/core/utils/ui_labels.py
@@ -8,14 +8,17 @@ LABELS: Dict[str, str] = {
     "dpp_emision_pago": "Días Promedio a Pago (DPP)",
     "dic_emision_contab": "Días a Ingreso Contable (DIC)",
     "dcp_contab_pago": "Días desde Contabilización al Pago (DCP)",
-    "brecha_porcentaje": "Brecha % (facturado vs pagado)",
 }
 
 TOOLTIPS: Dict[str, str] = {
     "dpp_emision_pago": "Promedio de días entre emisión de factura y pago efectivo.",
     "dic_emision_contab": "Promedio de días entre emisión y registro contable.",
     "dcp_contab_pago": "Promedio de días entre contabilización y pago.",
-    "brecha_porcentaje": "Diferencia porcentual entre monto facturado (pagado) y monto pagado.",
+    "total_facturado": "Incluye todo el monto facturado del periodo, incluso facturas aún sin pago.",
+    "total_pagado": (
+        "Monto cubierto considerando pagos realizados y montos con cuenta especial (CE); "
+        "se contabiliza el monto CE cuando aplica."
+    ),
 }
 
 __all__ = ["LABELS", "TOOLTIPS"]

--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -1,4 +1,4 @@
-# 10_Tablero_KPI.py — KPI con brecha porcentual, promedios GLOBAL/LOCAL y histogramas alineados
+# 10_Tablero_KPI.py — KPI con promedios GLOBAL/LOCAL y histogramas alineados
 from __future__ import annotations
 
 import html
@@ -176,11 +176,13 @@ metric_cards = [
         "Monto total facturado",
         money(kpi["total_facturado"]),
         caption=f"Base: {int(kpi['docs_total']):,} doc.",
+        tooltip=TOOLTIPS["total_facturado"],
     ),
     _metric_card(
         "Total pagado",
         money(kpi["total_pagado"]),
         caption=f"Pagadas: {int(kpi['docs_pagados']):,}",
+        tooltip=TOOLTIPS["total_pagado"],
     ),
     _metric_card(
         LABELS["dpp_emision_pago"],
@@ -197,22 +199,8 @@ metric_cards = [
         _fmt_days_metric(mean_tpc_kpi),
         tooltip=TOOLTIPS["dcp_contab_pago"],
     ),
-    _metric_card(
-        LABELS["brecha_porcentaje"],
-        f"{one_decimal(kpi['brecha_pct'])}%",
-        tooltip=TOOLTIPS["brecha_porcentaje"],
-    ),
 ]
 safe_markdown('<div class="app-card-grid">' + "".join(metric_cards) + '</div>')
-
-safe_markdown(
-    f"""
-    <div class="app-note">
-        <strong>{LABELS["brecha_porcentaje"]}</strong> = 100 × (Total pagado − Total facturado) / max(Total facturado, 1).
-        Total facturado = {money(kpi['total_facturado'])} • Total pagado = {money(kpi['total_pagado'])}.
-    </div>
-    """,
-)
 
 # ====== KPIs por cuenta especial (Si/No) ======
 if "cuenta_especial" in df_filtered_common.columns:
@@ -233,7 +221,6 @@ if "cuenta_especial" in df_filtered_common.columns:
             (LABELS["dpp_emision_pago"], _fmt_days_metric(k["dpp"])),
             (LABELS["dic_emision_contab"], _fmt_days_metric(k["dic"])),
             (LABELS["dcp_contab_pago"], _fmt_days_metric(k["dcp"])),
-            (LABELS["brecha_porcentaje"], f"{one_decimal(k['brecha_pct'])}%"),
         ]
         segment_cards.append(
             _segment_card(title, money(k["total_facturado"]), stats)

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -278,12 +278,14 @@ def _card_html(
     tone: str = "default",
     stats: list[tuple[str, str]] | None = None,
     compact: bool = True,
+    tooltip: str | None = None,
 ) -> str:
     classes = ["app-card", "app-card--frost"]
     if compact:
         classes.append("app-card__mini")
     if tone == "accent":
         classes.append("app-card--accent")
+    tooltip_attr = f' title="{html.escape(str(tooltip))}"' if tooltip else ""
     title_html = html.escape(str(title))
     value_html = html.escape(str(value))
     subtitle_html = (
@@ -305,7 +307,7 @@ def _card_html(
         )
         stats_html = f'<div class="app-inline-stats">{pills}</div>'
     return (
-        f'<div class="{" ".join(classes)}">'
+        f'<div class="{" ".join(classes)}"{tooltip_attr}>'
         f'<div class="app-card__title">{title_html}</div>'
         f'<div class="app-card__value">{value_html}</div>'
         f'{subtitle_html}'
@@ -368,12 +370,14 @@ else:
             subtitle="Base filtrada",
             tag=f"{total_docs:,} doc.",
             tone="accent",
+            tooltip=TOOLTIPS["total_facturado"],
         ),
         _card_html(
             "Total pagado",
             money(kpi_total["total_pagado"]),
             subtitle="Facturas con pago registrado",
             tag=f"{total_pagadas:,} pagos",
+            tooltip=TOOLTIPS["total_pagado"],
         ),
         _card_html(
             LABELS["dpp_emision_pago"],
@@ -389,12 +393,6 @@ else:
             LABELS["dcp_contab_pago"],
             _fmt_days(kpi_total["dcp"]),
             subtitle=TOOLTIPS["dcp_contab_pago"],
-        ),
-        _card_html(
-            LABELS["brecha_porcentaje"],
-            _fmt_pct(kpi_total["brecha_pct"]),
-            subtitle=TOOLTIPS["brecha_porcentaje"],
-            tag_variant="warning",
         ),
     ]
     _render_cards(cards)
@@ -413,7 +411,6 @@ else:
                 (LABELS["dpp_emision_pago"], _fmt_days(k["dpp"])),
                 (LABELS["dic_emision_contab"], _fmt_days(k["dic"])),
                 (LABELS["dcp_contab_pago"], _fmt_days(k["dcp"])),
-                (LABELS["brecha_porcentaje"], _fmt_pct(k["brecha_pct"])),
             ]
             segment_cards.append(
                 _card_html(


### PR DESCRIPTION
## Summary
- añade tooltips aclaratorios para los montos facturado y pagado en las vistas de KPIs e informe asesor
- elimina la métrica de brecha porcentual de los tableros para evitar confusiones
- actualiza los textos de ayuda globales para reflejar las nuevas descripciones

## Testing
- python -m compileall core pages

------
https://chatgpt.com/codex/tasks/task_e_68e67621fe98832ca6f8ab40f1c50a52