### PR TITLE
Remove redundant local estado filters from dashboards

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -137,30 +137,6 @@ sede, org, prov, cc, oc, est, _prio_removed = advanced_filters_ui(
     df0, show_controls=["sede", "org", "prov", "cc", "oc"]
 )
 
-estado_doc_options = [
-    "Todos",
-    "Autorizado sin Pago",
-    "Pagado",
-    "Facturado Sin Autorizar",
-]
-default_estado_doc = st.session_state.get("estado_doc_local", estado_doc_options[0])
-if default_estado_doc not in estado_doc_options:
-    default_estado_doc = estado_doc_options[0]
-estado_doc_choice = st.radio(
-    "Tipo de Doc./Estado (local)",
-    estado_doc_options,
-    horizontal=True,
-    index=estado_doc_options.index(default_estado_doc),
-    key="estado_doc_local",
-)
-estado_doc_map = {
-    "Todos": None,
-    "Autorizado sin Pago": "autorizada_sin_pago",
-    "Pagado": "pagada",
-    "Facturado Sin Autorizar": "sin_autorizacion",
-}
-estado_doc_value = estado_doc_map.get(estado_doc_choice)
-
 common_filters = {
     "fac_range": (fac_ini, fac_fin),
     "pay_range": (pay_ini, pay_fin),
@@ -175,12 +151,7 @@ common_filters = {
 }
 
 df_common_no_estado = apply_common_filters(df0, common_filters).copy()
-df_filtered_common = df_common_no_estado
-if estado_doc_value and "estado_doc" in df_filtered_common.columns:
-    estado_norm = df_filtered_common["estado_doc"].astype(str)
-    df_filtered_common = df_filtered_common[estado_norm == str(estado_doc_value)].copy()
-else:
-    df_filtered_common = df_filtered_common.copy()
+df_filtered_common = df_common_no_estado.copy()
 
 df = df_common_no_estado
 

--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -37,33 +37,8 @@ fac_ini, fac_fin, pay_ini, pay_fin = general_date_filters_ui(df0)
 sede, org, prov, cc, oc, est, _prio_removed = advanced_filters_ui(
     df0, show_controls=['sede','org','prov','cc','oc']
 )
-estado_doc_options = [
-    "Todos",
-    "Autorizado sin Pago",
-    "Pagado",
-    "Facturado Sin Autorizar",
-]
-default_estado_doc = st.session_state.get("estado_doc_local", estado_doc_options[0])
-if default_estado_doc not in estado_doc_options:
-    default_estado_doc = estado_doc_options[0]
-estado_doc_choice = st.radio(
-    "Tipo de Doc./Estado (local)",
-    estado_doc_options,
-    horizontal=True,
-    index=estado_doc_options.index(default_estado_doc),
-    key="estado_doc_local",
-)
-estado_doc_map = {
-    "Todos": None,
-    "Autorizado sin Pago": "autorizada_sin_pago",
-    "Pagado": "pagada",
-    "Facturado Sin Autorizar": "sin_autorizacion",
-}
-estado_doc_value = estado_doc_map.get(estado_doc_choice)
 df = apply_general_filters(df0, fac_ini, fac_fin, pay_ini, pay_fin)
 df = apply_advanced_filters(df, sede, org, prov, cc, oc, est, prio=[])
-if estado_doc_value and "estado_doc" in df.columns:
-    df = df[df["estado_doc"].astype(str) == estado_doc_value]
 
 # Trabajamos con pagadas
 dfp = df[df["estado_pago"] == "pagada"].copy()

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -176,30 +176,6 @@ sede, org, prov, cc, oc, est, _ = advanced_filters_ui(
     df0, show_controls=["sede", "org", "prov", "cc", "oc"]
 )
 
-estado_doc_options = [
-    "Todos",
-    "Autorizado sin Pago",
-    "Pagado",
-    "Facturado Sin Autorizar",
-]
-default_estado_doc = st.session_state.get("estado_doc_local", estado_doc_options[0])
-if default_estado_doc not in estado_doc_options:
-    default_estado_doc = estado_doc_options[0]
-estado_doc_choice = st.radio(
-    "Tipo de Doc./Estado (local)",
-    estado_doc_options,
-    horizontal=True,
-    index=estado_doc_options.index(default_estado_doc),
-    key="estado_doc_local",
-)
-estado_doc_map = {
-    "Todos": None,
-    "Autorizado sin Pago": "autorizada_sin_pago",
-    "Pagado": "pagada",
-    "Facturado Sin Autorizar": "sin_autorizacion",
-}
-estado_doc_value = estado_doc_map.get(estado_doc_choice)
-
 common_filters = {
     "fac_range": (fac_ini, fac_fin),
     "pay_range": (pay_ini, pay_fin),
@@ -214,12 +190,7 @@ common_filters = {
 }
 
 df_common_no_estado = apply_common_filters(df0, common_filters).copy()
-df_filtered_common = df_common_no_estado
-if estado_doc_value and "estado_doc" in df_filtered_common.columns:
-    estado_norm = df_filtered_common["estado_doc"].astype(str)
-    df_filtered_common = df_filtered_common[estado_norm == str(estado_doc_value)].copy()
-else:
-    df_filtered_common = df_filtered_common.copy()
+df_filtered_common = df_common_no_estado.copy()
 
 df = df_common_no_estado
 


### PR DESCRIPTION
## Summary
- remove the redundant "Tipo de Doc./Estado (local)" radio from KPI, Rankings, and Informe Asesor pages
- rely on the existing global filters and keep the downstream data preparation unchanged

## Testing
- not run (streamlit app changes)


------
https://chatgpt.com/codex/tasks/task_e_68e67c6494e8832c8782973949f6e297