### PR TITLE
Normalize KPIs to rely on monto_ce and add facturado breakdown

### DIFF
--- a/core/utils/ui_labels.py
+++ b/core/utils/ui_labels.py
@@ -18,7 +18,7 @@ LABELS: Dict[str, str] = _SafeLookup(
         "dic_emision_contab": "Días a Ingreso Contable (DIC)",
         "dcp_contab_pago": "Días desde Contabilización al Pago (DCP)",
         "total_facturado": "Monto total facturado",
-        "total_pagado": "Monto total pagado",
+        "total_pagado_real": "Monto total pagado (real)",
     }
 )
 
@@ -28,10 +28,8 @@ TOOLTIPS: Dict[str, str] = _SafeLookup(
         "dic_emision_contab": "Promedio de días entre emisión y registro contable.",
         "dcp_contab_pago": "Promedio de días entre contabilización y pago.",
         "total_facturado": "Incluye todo el monto facturado del periodo, incluso facturas aún sin pago.",
-        "total_pagado": (
-            "Monto cubierto considerando pagos realizados y montos con cuenta especial (CE); "
-            "se contabiliza el monto CE cuando aplica."
-        ),
+        "total_pagado_real": "Se calcula con `monto_ce` en documentos pagados (fecha_ce o monto_ce > 0).",
+        "desglose_facturado": "Comparativo del monto facturado entre documentos pagados y pendientes.",
     }
 )
 

--- a/lib_report.py
+++ b/lib_report.py
@@ -336,7 +336,7 @@ def generate_pdf_report(
         story.append(Paragraph("<b>Resumen KPIs de Pagos (Facturas Pagadas)</b>", styles["body_left"]))
         kpi_txt = (
             f"• Monto Total Facturado: <b>{kpis.get('total_facturado','-')}</b><br/>"
-            f"• Total Pagado (autorizado): <b>{kpis.get('total_pagado','-')}</b><br/>"
+            f"• Total Pagado (real): <b>{kpis.get('total_pagado_real','-')}</b><br/>"
             f"• {LABELS['dpp_emision_pago']}: <b>{kpis.get('dso','-')}</b>"
         )
         story.append(Paragraph(kpi_txt, styles["body_left"]))

--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -47,10 +47,11 @@ def _stat_pill(label: str, value: str) -> str:
     )
 
 
-def _segment_card(title: str, primary: str, stats: list[tuple[str, str]]) -> str:
+def _segment_card(title: str, primary: str, stats: list[tuple[str, str]], *, tooltip: str | None = None) -> str:
     pills = "".join(_stat_pill(name, val) for name, val in stats)
+    tooltip_attr = f' title="{html.escape(tooltip)}"' if tooltip else ""
     return (
-        '<div class="app-card">'
+        f'<div class="app-card"{tooltip_attr}>'
         f'<div class="app-card__title">{title}</div>'
         f'<div class="app-card__value">{primary}</div>'
         f'<div class="app-inline-stats">{pills}</div>'
@@ -185,8 +186,13 @@ else:
 df = df_common_no_estado
 
 # Particiones útiles
-df_pag     = df[df["estado_pago"] == "pagada"].copy()
-df_no_pag  = df[df["estado_pago"] != "pagada"].copy()
+pagadas_mask_global = df.get("is_pagada") if "is_pagada" in df.columns else None
+if pagadas_mask_global is not None:
+    df_pag = df[pagadas_mask_global].copy()
+    df_no_pag = df[~pagadas_mask_global].copy()
+else:
+    df_pag = df[df["estado_pago"] == "pagada"].copy()
+    df_no_pag = df[df["estado_pago"] != "pagada"].copy()
 
 # ===================== KPIs principales =====================
 st.subheader("Metricas principales del periodo")
@@ -194,7 +200,8 @@ st.subheader("Metricas principales del periodo")
 kpi = compute_kpis(df_filtered_common)
 
 # ===== Base de pagos contabilizados (para DPP/DIC/DCP y promedios globales) =====
-df_pag_contab = df[(df["estado_pago"] == "pagada") &
+pagadas_mask_full = pagadas_mask_global if pagadas_mask_global is not None else df["estado_pago"].eq("pagada")
+df_pag_contab = df[pagadas_mask_full &
                    (pd.to_datetime(df.get("fecha_cc"), errors="coerce").notna())].copy()
 
 mean_dso_kpi = kpi["dpp"]
@@ -206,17 +213,20 @@ def _fmt_days_metric(value: float) -> str:
 
 
 metric_cards = [
-    _metric_card(
-        "Monto total facturado",
+    _segment_card(
+        "Facturado: Pagado vs Sin pagar",
         money(kpi["total_facturado"]),
-        caption=f"Base: {int(kpi['docs_total']):,} doc.",
-        tooltip=TOOLTIPS["total_facturado"],
+        [
+            ("Pagado", money(kpi["facturado_pagado"])),
+            ("Sin pagar", money(kpi["facturado_sin_pagar"])),
+        ],
+        tooltip=TOOLTIPS["desglose_facturado"],
     ),
     _metric_card(
-        "Total pagado",
-        money(kpi["total_pagado"]),
+        "Total pagado (real)",
+        money(kpi["total_pagado_real"]),
         caption=f"Pagadas: {int(kpi['docs_pagados']):,}",
-        tooltip=TOOLTIPS["total_pagado"],
+        tooltip=TOOLTIPS["total_pagado_real"],
     ),
     _metric_card(
         LABELS["dpp_emision_pago"],
@@ -251,7 +261,7 @@ if "cuenta_especial" in df_filtered_common.columns:
 
         stats = [
             ("Documentos", f"{int(k['docs_total']):,}"),
-            ("Total pagado", money(k["total_pagado"])),
+            ("Total pagado (real)", money(k["total_pagado_real"])),
             (LABELS["dpp_emision_pago"], _fmt_days_metric(k["dpp"])),
             (LABELS["dic_emision_contab"], _fmt_days_metric(k["dic"])),
             (LABELS["dcp_contab_pago"], _fmt_days_metric(k["dcp"])),

--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -9,6 +9,7 @@ from lib_common import (
     advanced_filters_ui, apply_advanced_filters, header_ui, style_table, money,
     sanitize_df, safe_markdown
 )
+from lib_metrics import ensure_derived_fields
 from lib_report import excel_bytes_single, excel_bytes_multi
 
 # ================== Estilos globales de la tabla ==================
@@ -31,6 +32,8 @@ df0 = get_df_norm()
 if df0 is None:
     st.warning("Carga tus datos en 'Carga de Data'.")
     st.stop()
+
+df0 = ensure_derived_fields(df0)
 
 # -------- Filtros globales (sin prioritario global) --------
 fac_ini, fac_fin, pay_ini, pay_fin = general_date_filters_ui(df0)
@@ -66,7 +69,11 @@ if estado_doc_value and "estado_doc" in df.columns:
     df = df[df["estado_doc"].astype(str) == estado_doc_value]
 
 # Trabajamos con pagadas
-dfp = df[df["estado_pago"] == "pagada"].copy()
+pagadas_mask_global = df.get("is_pagada") if "is_pagada" in df.columns else None
+if pagadas_mask_global is not None:
+    dfp = df[pagadas_mask_global].copy()
+else:
+    dfp = df[df["estado_pago"] == "pagada"].copy()
 if dfp.empty:
     st.info("No hay facturas pagadas con los filtros actuales.")
     st.stop()
@@ -121,7 +128,7 @@ orden_metric = col_r2.radio(
 def _agg_base(df_in: pd.DataFrame, group_col: str) -> pd.DataFrame:
     """
     Devuelve agregación por grupo con:
-      - Monto Pagado (antes Contabilizado) / Cantidad Documentos
+      - Monto Pagado (real) / Cantidad Documentos
       - Cantidad Prioritario / % Prioritario (1 decimal)
       - Cantidad Cuenta Especial / % Cuenta Especial (1 decimal)
       - Mayoría: Proveedor Prioritario (Sí/No), Cuenta Especial (Sí/No)
@@ -138,12 +145,12 @@ def _agg_base(df_in: pd.DataFrame, group_col: str) -> pd.DataFrame:
          .assign(
              prov_prioritario=df_in.get("prov_prioritario", False).astype(bool),
              cuenta_especial=df_in.get("cuenta_especial", False).astype(bool),
-             monto_autorizado=pd.to_numeric(df_in.get("monto_autorizado", 0.0), errors="coerce").fillna(0.0),
+             monto_ce=pd.to_numeric(df_in.get("monto_ce", df_in.get("monto_pagado", 0.0)), errors="coerce").fillna(0.0),
          )
          .groupby(group_col, dropna=False)
          .agg(
              **{
-                 "Monto Pagado": ("monto_autorizado", "sum"),
+                 "Monto Pagado": ("monto_ce", "sum"),
                  "Cantidad Documentos": (group_col, "count"),
                  "Cantidad Prioritario": ("prov_prioritario", "sum"),
                  "Cantidad Cuenta Especial": ("cuenta_especial", "sum"),
@@ -325,19 +332,19 @@ def _resumen_dim(df_in: pd.DataFrame, flag_col: str, nombre_si: str, nombre_no: 
 
     tmp = df_in.assign(
         monto_autorizado=pd.to_numeric(df_in.get("monto_autorizado", 0.0), errors="coerce").fillna(0.0),
-        monto_pagado=pd.to_numeric(df_in.get("monto_pagado", 0.0), errors="coerce").fillna(0.0),
+        monto_ce=pd.to_numeric(df_in.get("monto_ce", df_in.get("monto_pagado", 0.0)), errors="coerce").fillna(0.0),
     )
 
     total_docs = len(tmp)
     total_aut = float(tmp["monto_autorizado"].sum())
-    total_pag = float(tmp["monto_pagado"].sum())
+    total_pag = float(tmp["monto_ce"].sum())
 
     g = (tmp.groupby(flag_col)
              .agg(
                  **{
                      "Cantidad Documentos": (flag_col, "count"),
                      "Monto Contabilizado": ("monto_autorizado", "sum"),
-                     "Monto Pagado": ("monto_pagado", "sum"),
+                     "Monto Pagado": ("monto_ce", "sum"),
                  }
              )
              .reset_index()


### PR DESCRIPTION
## Summary
- centralize payment-state logic in `lib_metrics.compute_kpis`, deriving `is_pagada` and all monetary KPIs from `monto_ce`, plus expose the facturado breakdown helpers
- refresh KPI cards in Tablero and Informe to highlight the new "Facturado: Pagado vs Sin pagar" split, rename the paid total to "Total pagado (real)", and propagate the tooltip and counts
- align rankings, summaries, and PDF output with the real paid amounts by sourcing `monto_ce`

## Testing
- python -m compileall lib_metrics.py pages core/utils lib_report.py


------
https://chatgpt.com/codex/tasks/task_e_68e67c8b8f00832cb3772ade3116411c