### PR TITLE
Normalizar cálculo de pago real y actualizar tableros

### DIFF
--- a/core/utils/ui_labels.py
+++ b/core/utils/ui_labels.py
@@ -28,7 +28,7 @@ TOOLTIPS: Dict[str, str] = _SafeLookup(
         "dic_emision_contab": "Promedio de días entre emisión y registro contable.",
         "dcp_contab_pago": "Promedio de días entre contabilización y pago.",
         "total_facturado": "Incluye todo el monto facturado del periodo, incluso facturas aún sin pago.",
-        "total_pagado_real": "Se calcula con `monto_ce` en documentos pagados (fecha_ce o monto_ce > 0).",
+        "total_pagado_real": "Suma `monto_pagado_real`: prioriza monto autorizado con fecha de pago, luego monto pagado registrado.",
         "desglose_facturado": "Comparativo del monto facturado entre documentos pagados y pendientes.",
     }
 )


### PR DESCRIPTION
## Summary
- implement a reusable `compute_monto_pagado_real` helper and update KPI aggregation to prioritise authorised amounts when a payment date exists
- propagate the new real payment totals and facturado breakdown to the KPI dashboard, rankings page, and advisor report, including new cards
- refresh the tooltip description for the real payment total to reflect the new business logic

## Testing
- python - <<'PY'
import pandas as pd
from lib_metrics import compute_monto_pagado_real, compute_kpis

rows = [
    {"fecha_pagado": "2025-01-10", "monto_pagado": 1000, "monto_autorizado": 1200, "monto_facturado": 1500, "fac_monto_total": 1500, "fecha_emision": "2025-01-05"},
    {"fecha_pagado": "2025-01-12", "monto_pagado": 800, "monto_autorizado": None, "monto_facturado": 900, "fac_monto_total": 900, "fecha_emision": "2025-01-06"},
    {"fecha_pagado": "2025-01-15", "monto_pagado": 0, "monto_autorizado": 500, "monto_facturado": 500, "fac_monto_total": 500, "fecha_emision": "2025-01-07"},
    {"fecha_pagado": None, "monto_pagado": 300, "monto_autorizado": None, "monto_facturado": 400, "fac_monto_total": 400, "fecha_emision": "2025-01-08"},
]

df = pd.DataFrame(rows)
print("monto_pagado_real", list(compute_monto_pagado_real(df)))
print("kpis", compute_kpis(df))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e683612520832cbed94c42016309f8