### PR TITLE
Improve compatibility with pre-3.10 Python by using typing unions

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@
 import pandas as pd
 import streamlit as st
 
+from typing import List, Optional
+
 from lib_common import (
     # setup / UI
     init_session_keys, read_any, style_table, header_ui, sanitize_df, safe_markdown,
@@ -47,8 +49,8 @@ def _card_html(
     rows: int,
     ready: bool,
     hint: str,
-    extras: list[str] | None = None,
-    actions: list[str] | None = None,
+    extras: Optional[List[str]] = None,
+    actions: Optional[List[str]] = None,
 ) -> str:
     status = "Listo" if ready else "Pendiente"
     trend_class = "app-card__trend app-card__trend--success" if ready else "app-card__trend app-card__trend--warning"

--- a/lib_common.py
+++ b/lib_common.py
@@ -7,7 +7,7 @@ warnings.filterwarnings("ignore")
 
 from datetime import date, datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -133,11 +133,11 @@ def read_any(file)->pd.DataFrame:
         raise ValueError(f"Formato de archivo no soportado: {name}")
 
 def style_table(
-    df: pd.DataFrame | Styler,
+    df: Union[pd.DataFrame, Styler],
     use_container_width: bool = True,
     height: int = 420,
     *,
-    visible_rows: int | None = None,
+    visible_rows: Optional[int] = None,
 ):
     """Renderiza una tabla con estilo consistente.
 
@@ -217,7 +217,7 @@ def style_table(
 # 4) Tema visual y cabecera
 # ============================================================
 _THEME_CSS_PATH = Path(__file__).resolve().parent / "styles" / "theme.css"
-_THEME_CSS_CACHE: str | None = None
+_THEME_CSS_CACHE: Optional[str] = None
 
 def load_ui_theme():
     """
@@ -233,7 +233,7 @@ def load_ui_theme():
     if _THEME_CSS_CACHE:
         safe_markdown(f"<style>{_THEME_CSS_CACHE}</style>")
 
-def header_ui(title: str, current_page: str, subtitle: str | None = None):
+def header_ui(title: str, current_page: str, subtitle: Optional[str] = None):
     load_ui_theme()
     safe_title = html.escape(str(title))
     safe_page = html.escape(str(current_page))
@@ -287,7 +287,7 @@ def init_session_keys():
         if k not in ss:
             ss[k] = v
 
-def get_df_norm()->pd.DataFrame|None:
+def get_df_norm() -> Optional[pd.DataFrame]:
     """Devuelve la base normalizada vigente en sesión (deduplicada)."""
     return st.session_state.get("df")
 
@@ -384,7 +384,7 @@ def merge_honorarios_con_bancos(df_honorarios: pd.DataFrame, df_bancos: pd.DataF
     return merged.drop(columns="_merge_key_cc")
 
 
-def load_honorarios(df_hon: pd.DataFrame) -> pd.DataFrame | None:
+def load_honorarios(df_hon: pd.DataFrame) -> Optional[pd.DataFrame]:
     """Normaliza y registra la base de honorarios en sesion."""
     ss = st.session_state
     if df_hon is None or df_hon.empty:
@@ -444,7 +444,7 @@ def load_honorarios(df_hon: pd.DataFrame) -> pd.DataFrame | None:
 
 
 # Helpers honorarios
-def get_honorarios_df() -> pd.DataFrame | None:
+def get_honorarios_df() -> Optional[pd.DataFrame]:
     df = st.session_state.get("honorarios")
     if isinstance(df, pd.DataFrame) and not df.empty:
         return df
@@ -735,7 +735,13 @@ def apply_general_filters(df: pd.DataFrame, fac_ini, fac_fin, pay_ini, pay_fin)-
         out = out[mask_pag]
     return out
 
-def advanced_filters_ui(df: pd.DataFrame, labels: dict|None=None, helps: dict|None=None, show_controls=None, **_):
+def advanced_filters_ui(
+    df: pd.DataFrame,
+    labels: Optional[dict] = None,
+    helps: Optional[dict] = None,
+    show_controls=None,
+    **_,
+):
     """
     Devuelve (sede, org, prov, cc, oc, est, prio)
     (El prio global se maneja localmente en cada página, por eso lo devolvemos vacío)
@@ -802,7 +808,7 @@ def apply_advanced_filters(df: pd.DataFrame, sede, org, prov, cc, oc, est, prio)
     return out
 # ——— Filtro “chip” de Sede (auto-descubre columna sede / sede_pago) ———
 
-def _detect_sede_col(df: pd.DataFrame) -> str | None:
+def _detect_sede_col(df: pd.DataFrame) -> Optional[str]:
     for c in ["sede", "sede_pago", "cmp_nombre"]:
         if c in df.columns:
             return c
@@ -840,7 +846,7 @@ def sede_chip_ui(df: pd.DataFrame, label: str = "Sede", key: str = "sede_chip"):
 
     return None if selected == "Todas" else selected
 
-def apply_sede_chip(df: pd.DataFrame, sede_sel: str | None) -> pd.DataFrame:
+def apply_sede_chip(df: pd.DataFrame, sede_sel: Optional[str]) -> pd.DataFrame:
     """Aplica el filtro de sede si corresponde; si sede_sel es None, no filtra."""
     col = _detect_sede_col(df)
     if not col or sede_sel is None:

--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import html
+from typing import List, Optional, Tuple
+
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
@@ -29,9 +31,9 @@ GRN  = "#2ecc71"
 def _metric_card(
     title: str,
     value: str,
-    caption: str | None = None,
+    caption: Optional[str] = None,
     *,
-    tooltip: str | None = None,
+    tooltip: Optional[str] = None,
 ) -> str:
     extra = f'<p class="app-card__subtitle">{caption}</p>' if caption else ""
     tooltip_attr = f' title="{html.escape(tooltip)}"' if tooltip else ""
@@ -52,7 +54,13 @@ def _stat_pill(label: str, value: str) -> str:
     )
 
 
-def _segment_card(title: str, primary: str, stats: list[tuple[str, str]], *, tooltip: str | None = None) -> str:
+def _segment_card(
+    title: str,
+    primary: str,
+    stats: List[Tuple[str, str]],
+    *,
+    tooltip: Optional[str] = None,
+) -> str:
     pills = "".join(_stat_pill(name, val) for name, val in stats)
     tooltip_attr = f' title="{html.escape(tooltip)}"' if tooltip else ""
     return (
@@ -80,7 +88,7 @@ def _render_range_cards(items: list[tuple[str, str]]):
     safe_markdown('<div class="app-range-card-grid">' + cards_html + '</div>')
 
 
-def _render_percentile_cards(items: list[tuple[str, str, str | None]]):
+def _render_percentile_cards(items: List[Tuple[str, str, Optional[str]]]):
     if not items:
         return
     cards = []

--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -1,8 +1,11 @@
 # pages/20_Rankings.py
 from __future__ import annotations
+from typing import Optional, List, Union
+
 import streamlit as st
 import pandas as pd
 import numpy as np
+from pandas.io.formats.style import Styler
 
 from lib_common import (
     get_df_norm, general_date_filters_ui, apply_general_filters,
@@ -156,7 +159,7 @@ def agregar_ranking(
     df_in: pd.DataFrame,
     group_col: str,
     nombre_col: str,
-    drop_cols: list[str] | None = None,
+    drop_cols: Optional[List[str]] = None,
 ) -> pd.DataFrame:
     agg = _agg_base(df_in, group_col)
     agg = agg.rename(columns={group_col: nombre_col})
@@ -195,7 +198,7 @@ def _format_money_cols_for_display(df_in: pd.DataFrame, cols: list[str]) -> pd.D
             df_disp[c] = df_disp[c].apply(lambda v: money(v) if pd.notnull(v) else v)
     return df_disp
 
-def _style_headers(df_disp: pd.DataFrame | pd.io.formats.style.Styler):
+def _style_headers(df_disp: Union[pd.DataFrame, Styler]):
     """
     Resalta encabezados (azul rey, texto blanco), agranda fuente (FONT_SIZE),
     y alinea valores a la derecha (estilo contable). No afecta exportación.

--- a/pages/40_Honorarios.py
+++ b/pages/40_Honorarios.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
+from typing import Optional, Dict
 
 from lib_common import (
     header_ui,
@@ -46,7 +47,7 @@ fecha_cols = {
     "pago": ["fecha_ce", "fecha_pagado"],
 }
 
-def _pick_col(df_in: pd.DataFrame, options: list[str]) -> str | None:
+def _pick_col(df_in: pd.DataFrame, options: list[str]) -> Optional[str]:
     for col in options:
         if col in df_in.columns:
             return col
@@ -194,7 +195,12 @@ def _amount_html(ce_val: float, no_val: float) -> str:
         "</div>"
     )
 
-def _render_metric_block(title: str, main_value: str, footer: str | None = None, breakdown_html: str | None = None):
+def _render_metric_block(
+    title: str,
+    main_value: str,
+    footer: Optional[str] = None,
+    breakdown_html: Optional[str] = None,
+):
     parts: list[str] = [
         "<div class='honorarios-metric-card'>",
         f"<div class='honorarios-metric-card__title'>{title}</div>",
@@ -408,7 +414,7 @@ if count_pagadas:
         bin_size = st.slider("Ancho de clase (dias)", 1, 60, 1, key="hon_hist_bin")
         hist_cols = st.columns(2)
 
-        def _stats(series: pd.Series) -> dict[str, float] | None:
+        def _stats(series: pd.Series) -> Optional[Dict[str, float]]:
             vals = series.dropna().to_numpy()
             if vals.size == 0:
                 return None

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -1,12 +1,15 @@
 # pages/60_Informe_Asesor.py
 from __future__ import annotations
 
+from datetime import datetime, date
+from typing import List, Optional, Tuple, Union
+
 import html
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
-from datetime import datetime, date
+from pandas.io.formats.style import Styler
 
 from core.utils import LABELS, TOOLTIPS
 from lib_common import (
@@ -117,7 +120,7 @@ _BUDGET_PANEL_STYLE = """
 """
 
 
-def _table_style(df_disp: pd.DataFrame | pd.io.formats.style.Styler):
+def _table_style(df_disp: Union[pd.DataFrame, Styler]):
     """Aplica el estilo de tablas usado en Rankings para tablas estáticas."""
 
     if isinstance(df_disp, pd.DataFrame):
@@ -244,7 +247,7 @@ def _agg_block(d: pd.DataFrame, mask):
 
 def _compute_presupuesto_selection(
     prior: pd.DataFrame, presupuesto: float
-) -> tuple[pd.DataFrame, float, float, dict | None]:
+) -> Tuple[pd.DataFrame, float, float, Optional[dict]]:
     """Devuelve selección acumulada, suma, saldo restante y próxima factura."""
 
     if prior is None or prior.empty:
@@ -288,14 +291,14 @@ def _compute_presupuesto_selection(
 def _card_html(
     title: str,
     value: str,
-    subtitle: str | None = None,
+    subtitle: Optional[str] = None,
     *,
-    tag: str | None = None,
+    tag: Optional[str] = None,
     tag_variant: str = "success",
     tone: str = "default",
-    stats: list[tuple[str, str]] | None = None,
+    stats: Optional[List[Tuple[str, str]]] = None,
     compact: bool = True,
-    tooltip: str | None = None,
+    tooltip: Optional[str] = None,
 ) -> str:
     classes = ["app-card", "app-card--frost"]
     if compact:


### PR DESCRIPTION
## Summary
- replace uses of Python 3.10 ``|`` union annotations with ``typing.Optional``/``typing.Union`` across shared libraries and Streamlit pages
- add the necessary typing imports (and Styler where required) to keep annotations valid under older Python versions

## Testing
- python -m compileall app.py lib_common.py lib_metrics.py pages

------
https://chatgpt.com/codex/tasks/task_e_68e68591e648832c9f953dceea05469e