### PR TITLE
Fix missing compute_dic_split import in KPI pages

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -20,6 +20,7 @@ from lib_metrics import (
     compute_kpis,
     apply_common_filters,
     compute_monto_pagado_real,
+    compute_dic_split,
 )
 from lib_report import excel_bytes_multi
 

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -22,6 +22,7 @@ from lib_metrics import (
     compute_kpis,
     apply_common_filters,
     compute_monto_pagado_real,
+    compute_dic_split,
 )
 from lib_report import excel_bytes_single, generate_pdf_report
 


### PR DESCRIPTION
## Summary
- import `compute_dic_split` in the KPI dashboard so the DIC breakdown is available
- add the same import to the advisor report which also relies on the helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e689456fc0832ca07c32783fe8e719