### PR TITLE
Remove redundant facturado metric cards

### DIFF
--- a/pages/10_Tablero_KPI.py
+++ b/pages/10_Tablero_KPI.py
@@ -232,14 +232,6 @@ metric_cards = [
         tooltip=TOOLTIPS["desglose_facturado"],
     ),
     _metric_card(
-        "Facturado pagado",
-        money(kpi["facturado_pagado"]),
-    ),
-    _metric_card(
-        "Facturado sin pagar",
-        money(kpi["facturado_sin_pagar"]),
-    ),
-    _metric_card(
         "Total pagado (real)",
         money(kpi["total_pagado_real"]),
         caption=f"Pagadas: {int(kpi['docs_pagados']):,}",

--- a/pages/60_Informe_Asesor.py
+++ b/pages/60_Informe_Asesor.py
@@ -402,14 +402,6 @@ else:
     total_pagadas = int(kpi_total["docs_pagados"])
     cards = [
         _card_html(
-            "Total facturado",
-            money(kpi_total["total_facturado"]),
-            subtitle="Base filtrada",
-            tag=f"{total_docs:,} doc.",
-            tone="accent",
-            tooltip=TOOLTIPS["total_facturado"],
-        ),
-        _card_html(
             "Desglose facturado",
             money(kpi_total["total_facturado"]),
             subtitle="Pagado vs sin pagar",
@@ -419,14 +411,6 @@ else:
             ],
             compact=False,
             tooltip=TOOLTIPS["desglose_facturado"],
-        ),
-        _card_html(
-            "Facturado pagado",
-            money(kpi_total["facturado_pagado"]),
-        ),
-        _card_html(
-            "Facturado sin pagar",
-            money(kpi_total["facturado_sin_pagar"]),
         ),
         _card_html(
             "Total pagado (real)",


### PR DESCRIPTION
## Summary
- remove the standalone Facturado pagado and Facturado sin pagar cards from the KPI dashboard
- drop the redundant Total facturado, Facturado pagado, and Facturado sin pagar cards from the financial advisor report

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e68b94fc8c832ca118c9adc0badefb