### PR TITLE
Ocultar filtros de fecha en todas las páginas

### DIFF
--- a/lib_common.py
+++ b/lib_common.py
@@ -712,16 +712,36 @@ def general_date_filters_ui(df: pd.DataFrame):
     if ss.get("pay_ini") is None:
         ss["pay_ini"], ss["pay_fin"] = pay_min, pay_max
 
-    st.subheader("Filtros Globales")
-    c1, c2 = st.columns(2)
-    with c1:
-        st.markdown("##### Fecha de Factura")
-        ss["fac_ini"] = st.date_input("Desde", value=ss["fac_ini"], key="fac_ini_ui", format="DD/MM/YYYY")
-        ss["fac_fin"] = st.date_input("Hasta", value=ss["fac_fin"], key="fac_fin_ui", format="DD/MM/YYYY")
-    with c2:
-        st.markdown("##### Fecha de Pago")
-        ss["pay_ini"] = st.date_input("Desde", value=ss["pay_ini"], key="pay_ini_ui", format="DD/MM/YYYY")
-        ss["pay_fin"] = st.date_input("Hasta", value=ss["pay_fin"], key="pay_fin_ui", format="DD/MM/YYYY")
+    with st.expander("▼ Filtros de Fecha", expanded=False):
+        c1, c2 = st.columns(2)
+        with c1:
+            st.markdown("##### Fecha de Factura")
+            ss["fac_ini"] = st.date_input(
+                "Desde",
+                value=ss["fac_ini"],
+                key="fac_ini_ui",
+                format="DD/MM/YYYY",
+            )
+            ss["fac_fin"] = st.date_input(
+                "Hasta",
+                value=ss["fac_fin"],
+                key="fac_fin_ui",
+                format="DD/MM/YYYY",
+            )
+        with c2:
+            st.markdown("##### Fecha de Pago")
+            ss["pay_ini"] = st.date_input(
+                "Desde",
+                value=ss["pay_ini"],
+                key="pay_ini_ui",
+                format="DD/MM/YYYY",
+            )
+            ss["pay_fin"] = st.date_input(
+                "Hasta",
+                value=ss["pay_fin"],
+                key="pay_fin_ui",
+                format="DD/MM/YYYY",
+            )
     return ss["fac_ini"], ss["fac_fin"], ss["pay_ini"], ss["pay_fin"]
 
 def apply_general_filters(df: pd.DataFrame, fac_ini, fac_fin, pay_ini, pay_fin)->pd.DataFrame:


### PR DESCRIPTION
## Summary
- mover los filtros globales de fecha a un expander colapsado para liberar espacio visual en todas las páginas

## Testing
- no se realizaron pruebas (cambio en la UI de Streamlit)


------
https://chatgpt.com/codex/tasks/task_e_68e68f310a74832c8ca32cb07739daaf