### PR TITLE
Adjust ranking page radio filter layout

### DIFF
--- a/pages/20_Rankings.py
+++ b/pages/20_Rankings.py
@@ -56,7 +56,7 @@ if dfp.empty:
     st.stop()
 
 # -------- Filtros LOCALES (solo esta página) --------
-col_l1, col_l2, col_l3 = st.columns([1,1,2])
+col_l1, col_l2 = st.columns(2)
 
 # Cuenta Especial (local)
 ce_local = "Todas"


### PR DESCRIPTION
## Summary
- widen the local filter columns on the Rankings page so radio options display horizontally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6921d2fa4832cb063227edf92fc5e